### PR TITLE
Fixed #97 upgrade google gcm library.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 4e05c4dd1a8106a87fee3b589dd32aecc7ffeb1246bed8f8516b32fe745034d6
-updated: 2016-05-07T23:52:16.479759881+08:00
+updated: 2016-06-04T17:18:47.875491257+08:00
 imports:
 - name: github.com/alecthomas/kingpin
   version: e1543c77ba157565dbf7b3e8e4e15087a120397f
@@ -55,7 +55,7 @@ imports:
 - name: github.com/golang/snappy
   version: d7b1e156f50d3c4664f683603af70e3e47fa0aa2
 - name: github.com/google/go-gcm
-  version: 1708036c4639349562068ad2d4df2364cd0a1004
+  version: 190e93b4cedb43562b5bd558eb1a1bbd38695bcd
 - name: github.com/gorilla/context
   version: a8d44e7d8e4d532b6a27a02dd82abb31cc1b01bd
 - name: github.com/gorilla/mux

--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -62,7 +62,7 @@ type PushNotification struct {
 	To                    string           `json:"to,omitempty"`
 	CollapseKey           string           `json:"collapse_key,omitempty"`
 	DelayWhileIdle        bool             `json:"delay_while_idle,omitempty"`
-	TimeToLive            uint             `json:"time_to_live,omitempty"`
+	TimeToLive            *uint            `json:"time_to_live,omitempty"`
 	RestrictedPackageName string           `json:"restricted_package_name,omitempty"`
 	DryRun                bool             `json:"dry_run,omitempty"`
 	Notification          gcm.Notification `json:"notification,omitempty"`
@@ -105,7 +105,7 @@ func CheckMessage(req PushNotification) error {
 	}
 
 	// ref: https://developers.google.com/cloud-messaging/http-server-ref
-	if req.Platform == PlatFormAndroid && (req.TimeToLive < 0 || 2419200 < req.TimeToLive) {
+	if req.Platform == PlatFormAndroid && req.TimeToLive != nil && (*req.TimeToLive < uint(0) || uint(2419200) < *req.TimeToLive) {
 		msg = "the message's TimeToLive field must be an integer " +
 			"between 0 and 2419200 (4 weeks)"
 		LogAccess.Debug(msg)

--- a/gorush/notification_test.go
+++ b/gorush/notification_test.go
@@ -175,6 +175,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 func TestAndroidNotificationStructure(t *testing.T) {
 
 	test := "test"
+	timeToLive := uint(100)
 	req := PushNotification{
 		Tokens:                []string{"a", "b"},
 		Message:               "Welcome",
@@ -183,7 +184,7 @@ func TestAndroidNotificationStructure(t *testing.T) {
 		CollapseKey:           "1",
 		ContentAvailable:      true,
 		DelayWhileIdle:        true,
-		TimeToLive:            100,
+		TimeToLive:            &timeToLive,
 		RestrictedPackageName: test,
 		DryRun:                true,
 		Title:                 test,
@@ -205,7 +206,7 @@ func TestAndroidNotificationStructure(t *testing.T) {
 	assert.Equal(t, "1", notification.CollapseKey)
 	assert.True(t, notification.ContentAvailable)
 	assert.True(t, notification.DelayWhileIdle)
-	assert.Equal(t, 100, int(notification.TimeToLive))
+	assert.Equal(t, uint(100), *notification.TimeToLive)
 	assert.Equal(t, test, notification.RestrictedPackageName)
 	assert.True(t, notification.DryRun)
 	assert.Equal(t, test, notification.Notification.Title)
@@ -499,22 +500,24 @@ func TestGCMMessage(t *testing.T) {
 
 	// the message's TimeToLive field must be an integer
 	// between 0 and 2419200 (4 weeks)
+	timeToLive := uint(2419201)
 	req = PushNotification{
 		Message:    "Test",
 		Platform:   PlatFormAndroid,
 		Tokens:     []string{"XXXXXXXXX"},
-		TimeToLive: 2419201,
+		TimeToLive: &timeToLive,
 	}
 
 	err = CheckMessage(req)
 	assert.Error(t, err)
 
 	// Pass
+	timeToLive = uint(86400)
 	req = PushNotification{
 		Message:    "Test",
 		Platform:   PlatFormAndroid,
 		Tokens:     []string{"XXXXXXXXX"},
-		TimeToLive: 86400,
+		TimeToLive: &timeToLive,
 	}
 
 	err = CheckMessage(req)
@@ -527,11 +530,12 @@ func TestCheckAndroidMessage(t *testing.T) {
 	PushConf.Android.Enabled = true
 	PushConf.Android.APIKey = os.Getenv("ANDROID_API_KEY")
 
+	timeToLive := uint(2419201)
 	req := PushNotification{
 		Tokens:     []string{"aaaaaa", "bbbbb"},
 		Platform:   PlatFormAndroid,
 		Message:    "Welcome",
-		TimeToLive: 2419201,
+		TimeToLive: &timeToLive,
 	}
 
 	success := PushToAndroid(req)


### PR DESCRIPTION
Change TimeToLive type to *unit

ref:
https://github.com/google/go-gcm/commit/bda37d790a88512b44abd034fb1db37eba62ae9d

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>