### PR TITLE
remove required field: message

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,21 +443,36 @@ Send normal notification.
     {
       "tokens": ["token_a", "token_b"],
       "platform": 1,
-      "message": "Hello World iOS!",
-      "title": "You got message"
+      "message": "Hello World iOS!"
     }
   ]
 ```
 
-The app icon be badged with the number `9` and that a bundled alert sound be played when the notification is delivered.
+The following payload asks the system to display an alert with a Close button and a single action button.The title and body keys provide the contents of the alert. The “PLAY” string is used to retrieve a localized string from the appropriate Localizable.strings file of the app. The resulting string is used by the alert as the title of an action button. This payload also asks the system to badge the app’s icon with the number 5.
 
 ```json
   "notifications": [
     {
       "tokens": ["token_a", "token_b"],
       "platform": 1,
-      "message": "Hello World iOS!",
-      "title": "You got message",
+      "badge": 5,
+      "alert": {
+        "title" : "Game Request",
+        "body" : "Bob wants to play poker",
+        "action-loc-key" : "PLAY"
+      }
+    }
+  ]
+```
+
+The following payload specifies that the device should display an alert message, plays a sound, and badges the app’s icon.
+
+```json
+  "notifications": [
+    {
+      "tokens": ["token_a", "token_b"],
+      "platform": 1,
+      "message": "You got your emails.",
       "badge": 9,
       "sound": "bingbong.aiff"
     }
@@ -472,7 +487,6 @@ Add other fields which user defined via `data` field.
       "tokens": ["token_a", "token_b"],
       "platform": 1,
       "message": "Hello World iOS!",
-      "title": "You got message",
       "data": {
         "key1": "welcome",
         "key2": 2

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Request body must has a notifications array. The following is a parameter table 
 |-------------------------|--------------|---------------------------------------------------------------------------------------------------|----------|---------------------------------------------------------------|
 | tokens                  | string array | device tokens                                                                                     | o        |                                                               |
 | platform                | int          | platform(iOS,Android)                                                                             | o        | 1=iOS, 2=Android                                              |
-| message                 | string       | message for notification                                                                          | o        |                                                               |
+| message                 | string       | message for notification                                                                          | -        |                                                               |
 | title                   | string       | notification title                                                                                | -        |                                                               |
 | priority                | string       | Sets the priority of the message.                                                                 | -        | `normal` or `high`                                            |
 | content_available       | bool         | data messages wake the app by default.                                                            | -        |                                                               |
@@ -406,6 +406,8 @@ Request body must has a notifications array. The following is a parameter table 
 
 | name           | type             | description                                                                                      | required | note |
 |----------------|------------------|--------------------------------------------------------------------------------------------------|----------|------|
+| title          | string           | Apple Watch & Safari display this string as part of the notification interface.                  | -        |      |
+| body           | string           | The text of the alert message.                  | -        |      |
 | subtitle       | string           | Apple Watch & Safari display this string as part of the notification interface.                  | -        |      |
 | action         | string           | The label of the action button. This one is required for Safari Push Notifications.              | -        |      |
 | action-loc-key | string           | If a string is specified, the system displays an alert that includes the Close and View buttons. | -        |      |
@@ -415,7 +417,7 @@ Request body must has a notifications array. The following is a parameter table 
 | title-loc-args | array of strings | Variable string values to appear in place of the format specifiers in title-loc-key.             | -        |      |
 | title-loc-key  | string           | The key to a title string in the Localizable.strings file for the current localization.          | -        |      |
 
-See more detail about [APNs Remote Notification Payload](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH107-SW1).
+See more detail about [APNs Remote Notification Payload](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW1).
 
 ### Android notification payload
 

--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -54,7 +54,7 @@ type PushNotification struct {
 	// Common
 	Tokens           []string `json:"tokens" binding:"required"`
 	Platform         int      `json:"platform" binding:"required"`
-	Message          string   `json:"message" binding:"required"`
+	Message          string   `json:"message,omitempty"`
 	Title            string   `json:"title,omitempty"`
 	Priority         string   `json:"priority,omitempty"`
 	ContentAvailable bool     `json:"content_available,omitempty"`
@@ -237,6 +237,10 @@ func iosAlertDictionary(payload *payload.Payload, req PushNotification) *payload
 
 	if len(req.Title) > 0 {
 		payload.AlertTitle(req.Title)
+	}
+
+	if len(req.Alert.Title) > 0 {
+		payload.AlertTitle(req.Alert.Title)
 	}
 
 	// Apple Watch & Safari display this string as part of the notification interface.

--- a/gorush/notification_test.go
+++ b/gorush/notification_test.go
@@ -216,6 +216,95 @@ func TestCheckSilentNotification(t *testing.T) {
 	assert.Nil(t, dat["aps"].(map[string]interface{})["badge"])
 }
 
+// URL: https://goo.gl/5xFo3C
+// Example 2
+// {
+//     "aps" : {
+//         "alert" : {
+//             "title" : "Game Request",
+//             "body" : "Bob wants to play poker",
+//             "action-loc-key" : "PLAY"
+//         },
+//         "badge" : 5
+//     },
+//     "acme1" : "bar",
+//     "acme2" : [ "bang",  "whiz" ]
+// }
+func TestAlertStringExample2ForIos(t *testing.T) {
+	var dat map[string]interface{}
+
+	test := "test"
+	title := "Game Request"
+	body := "Bob wants to play poker"
+	actionLocKey := "PLAY"
+	req := PushNotification{
+		ApnsID:   test,
+		Topic:    test,
+		Priority: "normal",
+		Alert: Alert{
+			Title:        title,
+			Body:         body,
+			ActionLocKey: actionLocKey,
+		},
+	}
+
+	notification := GetIOSNotification(req)
+
+	dump, _ := json.Marshal(notification.Payload)
+	data := []byte(string(dump))
+
+	if err := json.Unmarshal(data, &dat); err != nil {
+		log.Println(err)
+		panic(err)
+	}
+
+	assert.Equal(t, title, dat["aps"].(map[string]interface{})["alert"].(map[string]interface{})["title"])
+	assert.Equal(t, body, dat["aps"].(map[string]interface{})["alert"].(map[string]interface{})["body"])
+	assert.Equal(t, actionLocKey, dat["aps"].(map[string]interface{})["alert"].(map[string]interface{})["action-loc-key"])
+}
+
+// URL: https://goo.gl/5xFo3C
+// Example 3
+// {
+//     "aps" : {
+//         "alert" : "You got your emails.",
+//         "badge" : 9,
+//         "sound" : "bingbong.aiff"
+//     },
+//     "acme1" : "bar",
+//     "acme2" : 42
+// }
+func TestAlertStringExample3ForIos(t *testing.T) {
+	var dat map[string]interface{}
+
+	test := "test"
+	badge := 9
+	sound := "bingbong.aiff"
+	req := PushNotification{
+		ApnsID:           test,
+		Topic:            test,
+		Priority:         "normal",
+		ContentAvailable: true,
+		Message:          test,
+		Badge:            &badge,
+		Sound:            sound,
+	}
+
+	notification := GetIOSNotification(req)
+
+	dump, _ := json.Marshal(notification.Payload)
+	data := []byte(string(dump))
+
+	if err := json.Unmarshal(data, &dat); err != nil {
+		log.Println(err)
+		panic(err)
+	}
+
+	assert.Equal(t, sound, dat["aps"].(map[string]interface{})["sound"])
+	assert.Equal(t, float64(badge), dat["aps"].(map[string]interface{})["badge"].(float64))
+	assert.Equal(t, test, dat["aps"].(map[string]interface{})["alert"])
+}
+
 func TestIOSAlertNotificationStructure(t *testing.T) {
 	var dat map[string]interface{}
 


### PR DESCRIPTION
Fix #162
Fix #146

Add some example about ios notification.

```json
  "notifications": [
    {
      "tokens": ["token_a", "token_b"],
      "platform": 1,
      "badge": 5,
      "alert": {
        "title" : "Game Request",
        "body" : "Bob wants to play poker",
        "action-loc-key" : "PLAY"
      }
    }
  ]
```

or

```json
  "notifications": [
    {
      "tokens": ["token_a", "token_b"],
      "platform": 1,
      "message": "You got your emails.",
      "badge": 9,
      "sound": "bingbong.aiff"
    }
  ]
```