### PR TITLE
refactor: Support empty notification for android

### DIFF
--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -86,11 +86,6 @@ type PushNotification struct {
 // CheckMessage for check request message
 func CheckMessage(req PushNotification) error {
 	var msg string
-	if req.Message == "" {
-		msg = "the message must not be empty"
-		LogAccess.Debug(msg)
-		return errors.New(msg)
-	}
 
 	if len(req.Tokens) == 0 {
 		msg = "the message must specify at least one registration ID"
@@ -432,7 +427,7 @@ func GetAndroidNotification(req PushNotification) gcm.HttpMessage {
 	notification.Notification = &req.Notification
 
 	// Set request message if body is empty
-	if len(notification.Notification.Body) == 0 {
+	if len(req.Message) > 0 {
 		notification.Notification.Body = req.Message
 	}
 

--- a/gorush/notification_test.go
+++ b/gorush/notification_test.go
@@ -407,6 +407,16 @@ func TestAndroidNotificationStructure(t *testing.T) {
 	assert.Equal(t, "Welcome", notification.Notification.Body)
 	assert.Equal(t, "1", notification.Data["a"])
 	assert.Equal(t, 2, notification.Data["b"])
+
+	// test empty body
+	req = PushNotification{
+		Tokens: []string{"a", "b"},
+		To:     test,
+	}
+	notification = GetAndroidNotification(req)
+
+	assert.Equal(t, test, notification.To)
+	assert.Equal(t, "", notification.Notification.Body)
 }
 
 func TestPushToIOS(t *testing.T) {
@@ -653,14 +663,6 @@ func TestAPNSClientProdHost(t *testing.T) {
 func TestGCMMessage(t *testing.T) {
 	var req PushNotification
 	var err error
-
-	// the message must not be empty
-	req = PushNotification{
-		Message: "",
-	}
-
-	err = CheckMessage(req)
-	assert.Error(t, err)
 
 	// the message must specify at least one registration ID
 	req = PushNotification{


### PR DESCRIPTION
Fix #169

https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support

See `Table 2b. Android — keys for notification messages`

`body` can be optional.