### PR TITLE
feature(server): allow to bind specific addresses

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type ConfYaml struct {
 // SectionCore is sub section of config.
 type SectionCore struct {
 	Enabled         bool           `yaml:"enabled"`
+	Address         string         `yaml:"address"`
 	Port            string         `yaml:"port"`
 	MaxNotification int64          `yaml:"max_notification"`
 	WorkerNum       int64          `yaml:"worker_num"`
@@ -128,6 +129,7 @@ func BuildDefaultPushConf() ConfYaml {
 	var conf ConfYaml
 
 	// Core
+	conf.Core.Address = ""
 	conf.Core.Port = "8088"
 	conf.Core.Enabled = true
 	conf.Core.WorkerNum = int64(runtime.NumCPU())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,6 +55,7 @@ func (suite *ConfigTestSuite) SetupTest() {
 
 func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	// Core
+	assert.Equal(suite.T(), "", suite.ConfGorushDefault.Core.Address)
 	assert.Equal(suite.T(), "8088", suite.ConfGorushDefault.Core.Port)
 	assert.Equal(suite.T(), true, suite.ConfGorushDefault.Core.Enabled)
 	assert.Equal(suite.T(), int64(runtime.NumCPU()), suite.ConfGorushDefault.Core.WorkerNum)

--- a/gorush/server_unix.go
+++ b/gorush/server_unix.go
@@ -36,13 +36,13 @@ func RunHTTPServer() (err error) {
 		}
 
 		err = gracehttp.Serve(&http.Server{
-			Addr:      ":" + PushConf.Core.Port,
+			Addr:      PushConf.Core.Address + ":" + PushConf.Core.Port,
 			Handler:   routerEngine(),
 			TLSConfig: config,
 		})
 	} else {
 		err = gracehttp.Serve(&http.Server{
-			Addr:    ":" + PushConf.Core.Port,
+			Addr:    PushConf.Core.Address + ":" + PushConf.Core.Port,
 			Handler: routerEngine(),
 		})
 	}

--- a/gorush/server_windows.go
+++ b/gorush/server_windows.go
@@ -17,9 +17,9 @@ func RunHTTPServer() (err error) {
 		s := autoTLSServer()
 		err = s.ListenAndServeTLS("", "")
 	} else if PushConf.Core.SSL && PushConf.Core.CertPath != "" && PushConf.Core.KeyPath != "" {
-		err = http.ListenAndServeTLS(":"+PushConf.Core.Port, PushConf.Core.CertPath, PushConf.Core.KeyPath, routerEngine())
+		err = http.ListenAndServeTLS(PushConf.Core.Address+":"+PushConf.Core.Port, PushConf.Core.CertPath, PushConf.Core.KeyPath, routerEngine())
 	} else {
-		err = http.ListenAndServe(":"+PushConf.Core.Port, routerEngine())
+		err = http.ListenAndServe(PushConf.Core.Address+":"+PushConf.Core.Port, routerEngine())
 	}
 
 	return

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var usageStr = `
 Usage: gorush [options]
 
 Server Options:
+    -A, --address <address>          Address to bind (default: any)
     -p, --port <port>                Use port for clients (default: 8088)
     -c, --config <file>              Configuration file path
     -m, --message <message>          Notification message
@@ -118,6 +119,8 @@ func main() {
 	flag.StringVar(&opts.Ios.Password, "password", "", "iOS certificate password for gorush")
 	flag.StringVar(&opts.Android.APIKey, "k", "", "Android api key configuration for gorush")
 	flag.StringVar(&opts.Android.APIKey, "apikey", "", "Android api key configuration for gorush")
+	flag.StringVar(&opts.Core.Address, "A", "", "address to bind")
+	flag.StringVar(&opts.Core.Address, "address", "", "address to bind")
 	flag.StringVar(&opts.Core.Port, "p", "", "port number for gorush")
 	flag.StringVar(&opts.Core.Port, "port", "", "port number for gorush")
 	flag.StringVar(&token, "t", "", "token string")
@@ -185,14 +188,16 @@ func main() {
 		gorush.PushConf.Stat.Redis.Addr = opts.Stat.Redis.Addr
 	}
 
-	// overwrite server port
+	// overwrite server port and address
 	if opts.Core.Port != "" {
 		gorush.PushConf.Core.Port = opts.Core.Port
+	}
+	if opts.Core.Address != "" {
+		gorush.PushConf.Core.Address = opts.Core.Address
 	}
 
 	if err = gorush.InitLog(); err != nil {
 		log.Println(err)
-
 		return
 	}
 


### PR DESCRIPTION
The main use case for ooniprobe is to bind 127.0.0.1 only.