### PR TITLE
Expand environment variables in yaml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"runtime"
 
+	"github.com/pazams/envexpand"
 	"gopkg.in/yaml.v2"
 )
 
@@ -197,12 +198,13 @@ func LoadConfYaml(confPath string) (ConfYaml, error) {
 	var config ConfYaml
 
 	configFile, err := ioutil.ReadFile(confPath)
+	configFileExpanded := envexpand.Expand(configFile)
 
 	if err != nil {
 		return config, err
 	}
 
-	err = yaml.Unmarshal(configFile, &config)
+	err = yaml.Unmarshal(configFileExpanded, &config)
 
 	if err != nil {
 		return config, err

--- a/config/config_env_test.yml
+++ b/config/config_env_test.yml
@@ -1,0 +1,3 @@
+core:
+  port: "${GORUSH_ENV_TEST_PORT}"
+  mode: "${GORUSH_ENV_TEST_MISSING}"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,6 +42,7 @@ type ConfigTestSuite struct {
 	suite.Suite
 	ConfGorushDefault ConfYaml
 	ConfGorush        ConfYaml
+	ConfGorushEnv     ConfYaml
 }
 
 func (suite *ConfigTestSuite) SetupTest() {
@@ -50,6 +51,14 @@ func (suite *ConfigTestSuite) SetupTest() {
 	suite.ConfGorush, err = LoadConfYaml("config.yml")
 	if err != nil {
 		panic("failed to load config.yml")
+	}
+
+	os.Setenv("GORUSH_ENV_TEST_PORT", "9000")
+	defer os.Unsetenv("GORUSH_ENV_TEST_PORT")
+
+	suite.ConfGorushEnv, err = LoadConfYaml("config_env_test.yml")
+	if err != nil {
+		panic("failed to load config_env_test.yml")
 	}
 }
 
@@ -182,6 +191,14 @@ func (suite *ConfigTestSuite) TestValidateConf() {
 	// gRPC
 	assert.Equal(suite.T(), false, suite.ConfGorush.GRPC.Enabled)
 	assert.Equal(suite.T(), "50051", suite.ConfGorush.GRPC.Port)
+}
+
+func (suite *ConfigTestSuite) TestValidateConfEnvExpansion() {
+	assert.Equal(suite.T(), "9000", suite.ConfGorushEnv.Core.Port)
+}
+
+func (suite *ConfigTestSuite) TestValidateConfMissingEnvExpansion() {
+	assert.Equal(suite.T(), "${GORUSH_ENV_TEST_MISSING}", suite.ConfGorushEnv.Core.Mode)
 }
 
 func TestConfigTestSuite(t *testing.T) {

--- a/vendor/github.com/pazams/envexpand/LICENSE
+++ b/vendor/github.com/pazams/envexpand/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Maor Zamski
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pazams/envexpand/envexpand.go
+++ b/vendor/github.com/pazams/envexpand/envexpand.go
@@ -1,0 +1,77 @@
+package envexpand
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+var re = regexp.MustCompile(`^\${([a-zA-Z][a-zA-Z0-9_]*)}`)
+
+func Expand(template []byte) []byte {
+	str := ExpandString(string(template))
+	return []byte(str)
+}
+
+func ExpandString(template string) string {
+	ret := make([]byte, 0)
+
+	for len(template) > 0 {
+		i := strings.Index(template, "$")
+		if i < 0 {
+			break
+		}
+		ret = append(ret, template[:i]...)
+		template = template[i:]
+		if len(template) > 1 && template[1] == '$' {
+			// Treat $$ as $.
+			ret = append(ret, '$')
+			template = template[2:]
+			continue
+		}
+		name, rest, ok := extract(template)
+
+		if !ok {
+			// Malformed; treat $ as raw text.
+			ret = append(ret, '$')
+			template = template[1:]
+			continue
+		}
+		template = rest
+
+		env, found := os.LookupEnv(name)
+
+		if found {
+			ret = append(ret, env...)
+		} else {
+			ret = append(ret, "${"+name+"}"...)
+		}
+
+	}
+	ret = append(ret, template...)
+	return string(ret)
+}
+
+// extract returns the name from a leading "${name}" in str.
+func extract(str string) (name string, rest string, ok bool) {
+
+	result := re.FindStringSubmatchIndex(str)
+
+	if len(result) < 4 {
+		return
+	}
+
+	start := result[2]
+	end := result[3]
+
+	// if no results for capture group
+	if start == end {
+		return
+	}
+
+	ok = true
+	name = str[start:end]
+	rest = str[end+1:]
+
+	return
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -191,6 +191,12 @@
 			"revisionTime": "2016-04-24T11:30:07Z"
 		},
 		{
+			"checksumSHA1": "eTeYxGuKi2PhdFmMC8lL4jDUgjI=",
+			"path": "github.com/pazams/envexpand",
+			"revision": "14502790946778747b5e5a6f13599146a9440e79",
+			"revisionTime": "2017-08-23T23:11:01Z"
+		},
+		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",


### PR DESCRIPTION
We meet again @appleboy 😄  Thanks for writing this server!

This PR adds the capability to expand environment variables in the YAML config
e.g
```yaml
core:
  port: "${GORUSH_PORT}"
```
This is similar to how docker-compose [allows it](https://docs.docker.com/compose/compose-file/#variable-substitution) 
This should also address the request at #180 