### PR TITLE
let apns support multi-cert 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,11 +62,13 @@ type SectionAndroid struct {
 
 // SectionIos is sub section of config.
 type SectionIos struct {
-	Enabled    bool   `yaml:"enabled"`
-	KeyPath    string `yaml:"key_path"`
-	Password   string `yaml:"password"`
-	Production bool   `yaml:"production"`
-	MaxRetry   int    `yaml:"max_retry"`
+	Enabled    bool              `yaml:"enabled"`
+	KeyPath    string            `yaml:"key_path"`
+	Password   string            `yaml:"password"`
+	Production bool              `yaml:"production"`
+	MaxRetry   int               `yaml:"max_retry"`
+	KeyMap     map[string]string `yaml:"key_map"`
+	KeyPass    map[string]string `yaml:"key_password"`
 }
 
 // SectionLog is sub section of config.

--- a/config/config.yml
+++ b/config/config.yml
@@ -43,6 +43,14 @@ ios:
   password: "" # certificate password, default as empty string.
   production: false
   max_retry: 0 # resend fail notification, default value zero is disabled
+  key_map:
+    cert1: "key.pem"
+    cert2: "cert2.pem"
+    cert3: "cert3.pem"
+  key_password:
+    cert1: ""
+    cert2: ""
+    cert3: ""
 
 log:
   format: "string" # string or json

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -162,6 +162,7 @@ func (suite *ConfigTestSuite) TestValidateConf() {
 	assert.Equal(suite.T(), "", suite.ConfGorush.Ios.Password)
 	assert.Equal(suite.T(), false, suite.ConfGorush.Ios.Production)
 	assert.Equal(suite.T(), 0, suite.ConfGorush.Ios.MaxRetry)
+	assert.Equal(suite.T(), "cert1.pem", suite.ConfGorush.Ios.KeyMap["cert1"])
 
 	// log
 	assert.Equal(suite.T(), "string", suite.ConfGorush.Log.Format)

--- a/gorush/global.go
+++ b/gorush/global.go
@@ -28,4 +28,6 @@ var (
 	LogError *logrus.Logger
 	// StatStorage implements the storage interface
 	StatStorage storage.Storage
+	// Extend
+	ApnsClients = make(map[string]*apns.Client, len(PushConf.Ios.KeyMap))
 )

--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -72,6 +72,7 @@ type PushNotification struct {
 	Notification          fcm.Notification `json:"notification,omitempty"`
 
 	// iOS
+	ApnsClient     string   `json:"apns_client,omitempty"`
 	Expiration     int64    `json:"expiration,omitempty"`
 	ApnsID         string   `json:"apns_id,omitempty"`
 	Topic          string   `json:"topic,omitempty"`

--- a/gorush/notification_apns_test.go
+++ b/gorush/notification_apns_test.go
@@ -349,7 +349,7 @@ func TestDisabledIosNotifications(t *testing.T) {
 
 	PushConf.Ios.Enabled = false
 	PushConf.Ios.KeyPath = "../certificate/certificate-valid.pem"
-	err := InitAPNSClient()
+	_, err := InitAPNSClient("")
 	assert.Nil(t, err)
 
 	PushConf.Android.Enabled = true
@@ -384,7 +384,7 @@ func TestWrongIosCertificateExt(t *testing.T) {
 
 	PushConf.Ios.Enabled = true
 	PushConf.Ios.KeyPath = "test"
-	err := InitAPNSClient()
+	_, err := InitAPNSClient("")
 
 	assert.Error(t, err)
 	assert.Equal(t, "wrong certificate key extension", err.Error())
@@ -395,9 +395,10 @@ func TestAPNSClientDevHost(t *testing.T) {
 
 	PushConf.Ios.Enabled = true
 	PushConf.Ios.KeyPath = "../certificate/certificate-valid.p12"
-	err := InitAPNSClient()
+	ApnsClients = make(map[string]*apns2.Client, len(PushConf.Ios.KeyMap))
+	client, err := InitAPNSClient("")
 	assert.Nil(t, err)
-	assert.Equal(t, apns2.HostDevelopment, ApnsClient.Host)
+	assert.Equal(t, apns2.HostDevelopment, client.Host)
 }
 
 func TestAPNSClientProdHost(t *testing.T) {
@@ -406,9 +407,10 @@ func TestAPNSClientProdHost(t *testing.T) {
 	PushConf.Ios.Enabled = true
 	PushConf.Ios.Production = true
 	PushConf.Ios.KeyPath = "../certificate/certificate-valid.pem"
-	err := InitAPNSClient()
+	ApnsClients = make(map[string]*apns2.Client, len(PushConf.Ios.KeyMap))
+	client, err := InitAPNSClient("")
 	assert.Nil(t, err)
-	assert.Equal(t, apns2.HostProduction, ApnsClient.Host)
+	assert.Equal(t, apns2.HostProduction, client.Host)
 }
 
 func TestPushToIOS(t *testing.T) {
@@ -416,7 +418,7 @@ func TestPushToIOS(t *testing.T) {
 
 	PushConf.Ios.Enabled = true
 	PushConf.Ios.KeyPath = "../certificate/certificate-valid.pem"
-	err := InitAPNSClient()
+	_, err := InitAPNSClient("")
 	assert.Nil(t, err)
 	err = InitAppStatus()
 	assert.Nil(t, err)
@@ -430,4 +432,49 @@ func TestPushToIOS(t *testing.T) {
 	// send fail
 	isError := PushToIOS(req)
 	assert.True(t, isError)
+}
+
+func TestProvideApnsClient(t *testing.T) {
+	PushConf = config.BuildDefaultPushConf()
+
+	PushConf.Ios.Enabled = true
+	PushConf.Ios.KeyPath = "../certificate/certificate-valid.pem"
+	ApnsClients = make(map[string]*apns2.Client, len(PushConf.Ios.KeyMap))
+	PushConf.Ios.KeyMap = map[string]string{"cert1": "../certificate/certificate-valid.pem"}
+	PushConf.Ios.KeyPass = map[string]string{"cert1": ""}
+
+	err := InitAppStatus()
+	assert.Nil(t, err)
+
+	req := PushNotification{
+		Tokens:     []string{"11aa01229f15f0f0c52029d8cf8cd0aeaf2365fe4cebc4af26cd6d76b7919ef7"},
+		Platform:   1,
+		Message:    "Welcome",
+		ApnsClient: "cert1",
+	}
+
+	// send fail
+	isError := PushToIOS(req)
+	assert.True(t, isError)
+}
+
+func TestProvideWrongApnsClient(t *testing.T) {
+	PushConf = config.BuildDefaultPushConf()
+
+	PushConf.Ios.Enabled = true
+	PushConf.Ios.KeyPath = "../certificate/certificate-valid.pem"
+	ApnsClients = make(map[string]*apns2.Client, len(PushConf.Ios.KeyMap))
+	err := InitAppStatus()
+	assert.Nil(t, err)
+
+	req := PushNotification{
+		Tokens:     []string{"11aa01229f15f0f0c52029d8cf8cd0aeaf2365fe4cebc4af26cd6d76b7919ef7"},
+		Platform:   1,
+		Message:    "Welcome",
+		ApnsClient: "cert_not_exist",
+	}
+
+	// send fail
+	isError := PushToIOS(req)
+	assert.False(t, isError)
 }

--- a/gorush/notification_test.go
+++ b/gorush/notification_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/appleboy/gorush/config"
+	"github.com/sideshow/apns2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,8 +30,6 @@ func TestSenMultipleNotifications(t *testing.T) {
 
 	PushConf.Ios.Enabled = true
 	PushConf.Ios.KeyPath = "../certificate/certificate-valid.pem"
-	err := InitAPNSClient()
-	assert.Nil(t, err)
 
 	PushConf.Android.Enabled = true
 	PushConf.Android.APIKey = os.Getenv("ANDROID_API_KEY")
@@ -64,8 +63,6 @@ func TestDisabledAndroidNotifications(t *testing.T) {
 
 	PushConf.Ios.Enabled = true
 	PushConf.Ios.KeyPath = "../certificate/certificate-valid.pem"
-	err := InitAPNSClient()
-	assert.Nil(t, err)
 
 	PushConf.Android.Enabled = false
 	PushConf.Android.APIKey = os.Getenv("ANDROID_API_KEY")
@@ -99,8 +96,7 @@ func TestSyncModeForNotifications(t *testing.T) {
 
 	PushConf.Ios.Enabled = true
 	PushConf.Ios.KeyPath = "../certificate/certificate-valid.pem"
-	err := InitAPNSClient()
-	assert.Nil(t, err)
+	ApnsClients = make(map[string]*apns2.Client, len(PushConf.Ios.KeyMap))
 
 	PushConf.Android.Enabled = true
 	PushConf.Android.APIKey = os.Getenv("ANDROID_API_KEY")

--- a/gorush/worker.go
+++ b/gorush/worker.go
@@ -1,6 +1,7 @@
 package gorush
 
 import (
+	"fmt"
 	"sync"
 )
 
@@ -41,6 +42,11 @@ func queueNotification(req RequestPush) (int, []LogPushEntry) {
 			if !PushConf.Ios.Enabled {
 				continue
 			}
+			if len(notification.ApnsClient) > 0 {
+				if _, ok := PushConf.Ios.KeyMap[notification.ApnsClient]; !ok {
+					continue
+				}
+			}
 		case PlatFormAndroid:
 			if !PushConf.Android.Enabled {
 				continue
@@ -56,6 +62,7 @@ func queueNotification(req RequestPush) (int, []LogPushEntry) {
 			notification.log = &log
 			notification.AddWaitCount()
 		}
+		fmt.Println("-----")
 		QueueNotification <- notification
 		count += len(notification.Tokens)
 	}

--- a/main.go
+++ b/main.go
@@ -189,7 +189,7 @@ func main() {
 			return
 		}
 
-		if err := gorush.InitAPNSClient(); err != nil {
+		if _, err := gorush.InitAPNSClient(""); err != nil {
 			return
 		}
 		gorush.PushToIOS(req)
@@ -220,7 +220,8 @@ func main() {
 	var g errgroup.Group
 
 	g.Go(func() error {
-		return gorush.InitAPNSClient()
+		_, err := gorush.InitAPNSClient("")
+		return err
 	})
 
 	g.Go(func() error {


### PR DESCRIPTION
I modified sort of the code, let the ios could support multiple certifications. The usage was same as the andriod platform. Make a request as followed
```
{
  "notifications": [
    {
      "tokens": ["token_a", "token_b"],
      "platform": 1,
      "message": "Hello World iOS!",
      "apns_client": "cert1",
    }
  ]
}
```
key "apns_client" will find the source from config.yaml.
Certificaton can set in config.yaml  as followed
```
ios:
  key_map:
    cert1: "key.pem"
    cert2: "cert2.pem"
    cert3: "cert3.pem"
  key_password:
    cert1: ""
    cert2: ""
    cert3: ""
```
#99 