### PR TITLE
Send messages to topics for android

### DIFF
--- a/gorush/notification_fcm_test.go
+++ b/gorush/notification_fcm_test.go
@@ -140,6 +140,26 @@ func TestFCMMessage(t *testing.T) {
 	err = CheckMessage(req)
 	assert.Error(t, err)
 
+	// ignore check token length if send topic message
+	req = PushNotification{
+		Message:  "Test",
+		Platform: PlatFormAndroid,
+		To:       "/topics/foo-bar",
+	}
+
+	err = CheckMessage(req)
+	assert.NoError(t, err)
+
+	// "condition": "'dogs' in topics || 'cats' in topics",
+	req = PushNotification{
+		Message:   "Test",
+		Platform:  PlatFormAndroid,
+		Condition: "'dogs' in topics || 'cats' in topics",
+	}
+
+	err = CheckMessage(req)
+	assert.NoError(t, err)
+
 	// the message may specify at most 1000 registration IDs
 	req = PushNotification{
 		Message:  "Test",

--- a/gorush/notification_test.go
+++ b/gorush/notification_test.go
@@ -132,6 +132,48 @@ func TestSyncModeForNotifications(t *testing.T) {
 	assert.Equal(t, 2, len(logs))
 }
 
+func TestSyncModeForTopicNotification(t *testing.T) {
+	PushConf, _ = config.LoadConf("")
+
+	PushConf.Android.Enabled = true
+	PushConf.Android.APIKey = os.Getenv("ANDROID_API_KEY")
+	PushConf.Log.HideToken = false
+
+	// enable sync mode
+	PushConf.Core.Sync = true
+
+	req := RequestPush{
+		Notifications: []PushNotification{
+			// android
+			{
+				// error:InvalidParameters
+				// Check that the provided parameters have the right name and type.
+				To:       "/topics/foo-bar@@@##",
+				Platform: PlatFormAndroid,
+				Message:  "This is a Firebase Cloud Messaging Topic Message!",
+			},
+			// android
+			{
+				// success
+				To:       "/topics/foo-bar",
+				Platform: PlatFormAndroid,
+				Message:  "This is a Firebase Cloud Messaging Topic Message!",
+			},
+			// android
+			{
+				// success
+				Condition: "'dogs' in topics || 'cats' in topics",
+				Platform:  PlatFormAndroid,
+				Message:   "This is a Firebase Cloud Messaging Topic Message!",
+			},
+		},
+	}
+
+	count, logs := queueNotification(req)
+	assert.Equal(t, 2, count)
+	assert.Equal(t, 1, len(logs))
+}
+
 func TestSetProxyURL(t *testing.T) {
 
 	err := SetProxy("87.236.233.92:8080")

--- a/gorush/worker.go
+++ b/gorush/worker.go
@@ -58,6 +58,10 @@ func queueNotification(req RequestPush) (int, []LogPushEntry) {
 		}
 		QueueNotification <- notification
 		count += len(notification.Tokens)
+		// Count topic message
+		if notification.To != "" {
+			count++
+		}
 	}
 
 	if PushConf.Core.Sync {

--- a/main.go
+++ b/main.go
@@ -130,10 +130,19 @@ func main() {
 	if opts.Android.Enabled {
 		gorush.PushConf.Android.Enabled = opts.Android.Enabled
 		req := gorush.PushNotification{
-			Tokens:   []string{token},
 			Platform: gorush.PlatFormAndroid,
 			Message:  message,
 			Title:    title,
+		}
+
+		// send message to single device
+		if token != "" {
+			req.Tokens = []string{token}
+		}
+
+		// send topic message
+		if topic != "" {
+			req.To = topic
 		}
 
 		err := gorush.CheckMessage(req)
@@ -159,12 +168,17 @@ func main() {
 
 		gorush.PushConf.Ios.Enabled = opts.Ios.Enabled
 		req := gorush.PushNotification{
-			Tokens:   []string{token},
 			Platform: gorush.PlatFormIos,
 			Message:  message,
 			Title:    title,
 		}
 
+		// send message to single device
+		if token != "" {
+			req.Tokens = []string{token}
+		}
+
+		// send topic message
 		if topic != "" {
 			req.Topic = topic
 		}
@@ -259,13 +273,13 @@ Server Options:
 iOS Options:
     -i, --key <file>                 certificate key file path
     -P, --password <password>        certificate key password
-    --topic <topic>                  iOS topic
     --ios                            enabled iOS (default: false)
     --production                     iOS production mode (default: false)
 Android Options:
     -k, --apikey <api_key>           Android API Key
     --android                        enabled android (default: false)
 Common Options:
+    --topic <topic>                  iOS or Android topic message
     -h, --help                       Show this message
     -v, --version                    Show version
 `

--- a/vendor/github.com/appleboy/go-fcm/README.md
+++ b/vendor/github.com/appleboy/go-fcm/README.md
@@ -1,14 +1,20 @@
 # go-fcm
 
-[![GoDoc](https://godoc.org/github.com/edganiukov/fcm?status.svg)](https://godoc.org/github.com/edganiukov/fcm)
-[![Build Status](https://travis-ci.org/edganiukov/fcm.svg?branch=master)](https://travis-ci.org/edganiukov/fcm)
-[![Go Report Card](https://goreportcard.com/badge/github.com/edganiukov/fcm)](https://goreportcard.com/report/github.com/edganiukov/fcm)
+[![GoDoc](https://godoc.org/github.com/appleboy/go-fcm?status.svg)](https://godoc.org/github.com/edganiukov/fcm)
+[![Build Status](https://travis-ci.org/appleboy/go-fcm.svg?branch=master)](https://travis-ci.org/edganiukov/fcm)
+[![Go Report Card](https://goreportcard.com/badge/github.com/appleboy/go-fcm)](https://goreportcard.com/report/github.com/edganiukov/fcm)
 
 This project was forked from [github.com/edganiukov/fcmfcm](https://github.com/edganiukov/fcm).
 
 Golang client library for Firebase Cloud Messaging. Implemented only [HTTP client](https://firebase.google.com/docs/cloud-messaging/http-server-ref#downstream).
 
 More information on [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging/)
+
+## Feature
+
+* [x] Send messages to a topic
+* [x] Send messages to a device list
+* [x] Supports condition attribute (fcm only)
 
 ## Getting Started
 
@@ -34,31 +40,32 @@ Here is a simple example illustrating how to use FCM library:
 package main
 
 import (
-	"github.com/edganiukov/fcm"
+	"log"
+
+	"github.com/appleboy/go-fcm"
 )
 
 func main() {
 	// Create the message to be sent.
 	msg := &fcm.Message{
-     		Token: "sample_device_token",
-      		Data: map[string]interface{}{
-         		"foo": "bar",
-      		}
-  	}
+		To: "sample_device_token",
+		Data: map[string]interface{}{
+			"foo": "bar",
+		},
+	}
 
 	// Create a FCM client to send the message.
-	client := fcm.NewClient("sample_api_key")
+	client, err := fcm.NewClient("sample_api_key")
+	if err != nil {
+		log.Fatalln(err)
+	}
 
 	// Send the message and receive the response without retries.
 	response, err := client.Send(msg)
 	if err != nil {
-		/* ... */
+		log.Fatalln(err)
 	}
-	/* ... */
+
+	log.Printf("%#v\n", response)
 }
 ```
-
-
-#### TODO:
----------
-- [ ] Retry only failed messages while multicast messaging.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "DuVew6znkXuUG1wjGQF+pUyXrHU=",
+			"checksumSHA1": "TVTjsXflagrWbTXmbxPJdCtTFRo=",
 			"path": "github.com/appleboy/go-fcm",
-			"revision": "5f2cb2866531e4e37c7a9ff5fb7a1536e1ffc566",
-			"revisionTime": "2017-06-01T07:42:50Z"
+			"revision": "c12f9e2e95b14802da2b4d3807dd12ef0dd80a42",
+			"revisionTime": "2017-10-24T08:00:40Z"
 		},
 		{
 			"checksumSHA1": "Ab7MUtqX0iq2PUzzBxWpgzPSydw=",


### PR DESCRIPTION
fix https://github.com/appleboy/gorush/issues/265

Using binary:

```
$ gorush --android --topic "/topics/foo-bar" -m "This is a Firebase Cloud Messaging Topic Message" -k xxxxxxxxxx
```

Send JSON file:

```
$ bat POST localhost:8088/api/push notifications:=@test.json
```

result:

```
POST /api/push HTTP/1.1
Host: localhost:8088
Accept: application/json
Accept-Encoding: gzip, deflate
Content-Type: application/json
User-Agent: bat/0.1.0


{"notifications":[{"message":"This is a Firebase Cloud Messaging Topic Message","platform":2,"to":"/topics/foo-bar"}]}


HTTP/1.1 200 OK
Content-Type : application/json; charset=utf-8
X-Drone-Version : v1.9.0-84-g098f9da
Date : Tue, 24 Oct 2017 08:42:56 GMT
Content-Length : 242


{
  "counts": 1,
  "logs": [],
  "success": "ok"
}
```
Data:

```json
{
  "notifications": [{
    "message": "This is a Firebase Cloud Messaging Topic Message",
    "platform": 2,
    "to": "/topics/foo-bar"
  }]
}
```

Server Log:

![screen shot 2017-10-24 at 4 57 35 pm](https://user-images.githubusercontent.com/21979/31933722-8a338f2e-b86f-11e7-86bb-42f371cbfb73.png)
