### PR TITLE
feat: Add ThreadID for apns

### DIFF
--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -80,6 +80,7 @@ type PushNotification struct {
 	Topic          string   `json:"topic,omitempty"`
 	Badge          *int     `json:"badge,omitempty"`
 	Category       string   `json:"category,omitempty"`
+	ThreadID       string   `json:"thread-id,omitempty"`
 	URLArgs        []string `json:"url-args,omitempty"`
 	Alert          Alert    `json:"alert,omitempty"`
 	MutableContent bool     `json:"mutable-content,omitempty"`

--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -166,6 +166,10 @@ func GetIOSNotification(req PushNotification) *apns2.Notification {
 		payload.URLArgs(req.URLArgs)
 	}
 
+	if len(req.ThreadID) > 0 {
+		payload.ThreadID(req.ThreadID)
+	}
+
 	for k, v := range req.Data {
 		payload.Custom(k, v)
 	}

--- a/gorush/notification_apns_test.go
+++ b/gorush/notification_apns_test.go
@@ -115,6 +115,7 @@ func TestSendZeroValueForBadgeKey(t *testing.T) {
 		Sound:            test,
 		ContentAvailable: true,
 		MutableContent:   true,
+		ThreadID:         test,
 	}
 
 	notification := GetIOSNotification(req)
@@ -130,6 +131,7 @@ func TestSendZeroValueForBadgeKey(t *testing.T) {
 	alert, _ := jsonparser.GetString(data, "aps", "alert")
 	badge, _ := jsonparser.GetInt(data, "aps", "badge")
 	sound, _ := jsonparser.GetString(data, "aps", "sound")
+	threadID, _ := jsonparser.GetString(data, "aps", "thread-id")
 	contentAvailable, _ := jsonparser.GetInt(data, "aps", "content-available")
 	mutableContent, _ := jsonparser.GetInt(data, "aps", "mutable-content")
 
@@ -143,6 +145,7 @@ func TestSendZeroValueForBadgeKey(t *testing.T) {
 	assert.Equal(t, message, alert)
 	assert.Equal(t, 0, int(badge))
 	assert.Equal(t, test, sound)
+	assert.Equal(t, test, threadID)
 	assert.Equal(t, 1, int(contentAvailable))
 	assert.Equal(t, 1, int(mutableContent))
 


### PR DESCRIPTION
Provide this key with a string value that represents the app-specific identifier for grouping notifications. If you provide a Notification Content app extension, you can use this value to group your notifications together. For local notifications, this key corresponds to the threadIdentifier property of the UNNotificationContent object.

see: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW1


