### PR TITLE
Set IOS key_path to an empty string

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,7 @@ android:
 
 ios:
   enabled: false
-  key_path: "key.pem"
+  key_path: ""
   key_base64: "" # load iOS key from base64 input
   key_type: "pem" # could be pem, p12 or p8 type
   password: "" # certificate password, default as empty string.


### PR DESCRIPTION
At the moment you can't start gorush with IOS base64 certificate provided using an ENV var. 

Apparently viper uses default value for the configuration field even if you set env var to an empty string. So `if var is not set` or `is set and string is empty` => default value.

Which means that if I only use env vars for configuration and I want to use IOS certificate in base64 I can not set `cert_path` to an empty string, so `gorush` uses base64 cert:

https://github.com/appleboy/gorush/blob/master/gorush/notification.go#L180

I.e.:
```
ORUSH_IOS_ENABLED=true GORUSH_IOS_KEY_PATH="" GORUSH_IOS_KEY_TYPE=p12  GORUSH_IOS_KEY_BASE64="SOME_BASE64" go run main.go
(config.SectionIos) {
 Enabled: (bool) true,
 KeyPath: (string) (len=7) "key.pem", <--- still key.pem
 KeyBase64: (string) (len=2) "SOME_BASE64",
 KeyType: (string) (len=3) "p12",
 Password: (string) "",
 Production: (bool) false,
 MaxRetry: (int) 0,
 KeyID: (string) "",
 TeamID: (string) ""
}
FATA[2018/06/10 - 12:42:09] certificate file does not exist
```
So by default `KeyPath` should an empty string. Then I can set only if I want.