### PR TITLE
Also build OpenBSD binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DEPLOY_ACCOUNT := appleboy
 DEPLOY_IMAGE := $(EXECUTABLE)
 GOFMT ?= gofmt "-s"
 
-TARGETS ?= linux darwin windows
+TARGETS ?= linux darwin windows openbsd
 ARCHS ?= amd64 386
 PACKAGES ?= $(shell $(GO) list ./... | grep -v /vendor/)
 GOFILES := $(shell find . -name "*.go" -type f -not -path "./vendor/*")


### PR DESCRIPTION
This patch simply adds `openbsd` to `TARGETS`. This is a supported Go architecture and the result will be binaries that can be run on 32 or 64-bit OpenBSD.

This project is hard to build on OpenBSD because it depends on some Linux-isms like *GNU Make* and specific `find` options. So it will be nice to have binaries easily available.