### PR TITLE
Added mutable_content option for Firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Request body must has a notifications array. The following is a parameter table 
 | badge                   | int          | badge count                                                                                       | -        | only iOS                                                      |
 | category                | string       | the UIMutableUserNotificationCategory object                                                      | -        | only iOS                                                      |
 | alert                   | string array | payload of a iOS message                                                                          | -        | only iOS. See the [detail](#ios-alert-payload)                |
-| mutable-content         | bool         | enable Notification Service app extension.                                                        | -        | only iOS(10.0+).                                              |
+| mutable_content         | bool         | enable Notification Service app extension.                                                        | -        | only iOS(10.0+).                                              |
 ### iOS alert payload
 
 | name           | type             | description                                                                                      | required | note |

--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -56,6 +56,7 @@ type PushNotification struct {
 	Title            string   `json:"title,omitempty"`
 	Priority         string   `json:"priority,omitempty"`
 	ContentAvailable bool     `json:"content_available,omitempty"`
+	MutableContent   bool     `json:"mutable_content,omitempty"`
 	Sound            string   `json:"sound,omitempty"`
 	Data             D        `json:"data,omitempty"`
 	Retry            int      `json:"retry,omitempty"`
@@ -74,18 +75,17 @@ type PushNotification struct {
 	Notification          fcm.Notification `json:"notification,omitempty"`
 
 	// iOS
-	Expiration     int64    `json:"expiration,omitempty"`
-	ApnsID         string   `json:"apns_id,omitempty"`
-	CollapseID     string   `json:"collapse_id,omitempty"`
-	Topic          string   `json:"topic,omitempty"`
-	Badge          *int     `json:"badge,omitempty"`
-	Category       string   `json:"category,omitempty"`
-	ThreadID       string   `json:"thread-id,omitempty"`
-	URLArgs        []string `json:"url-args,omitempty"`
-	Alert          Alert    `json:"alert,omitempty"`
-	MutableContent bool     `json:"mutable-content,omitempty"`
-	Production     bool     `json:"production,omitempty"`
-	Development    bool     `json:"development,omitempty"`
+	Expiration  int64    `json:"expiration,omitempty"`
+	ApnsID      string   `json:"apns_id,omitempty"`
+	CollapseID  string   `json:"collapse_id,omitempty"`
+	Topic       string   `json:"topic,omitempty"`
+	Badge       *int     `json:"badge,omitempty"`
+	Category    string   `json:"category,omitempty"`
+	ThreadID    string   `json:"thread-id,omitempty"`
+	URLArgs     []string `json:"url-args,omitempty"`
+	Alert       Alert    `json:"alert,omitempty"`
+	Production  bool     `json:"production,omitempty"`
+	Development bool     `json:"development,omitempty"`
 }
 
 // WaitDone decrements the WaitGroup counter.

--- a/gorush/notification_fcm.go
+++ b/gorush/notification_fcm.go
@@ -36,6 +36,7 @@ func GetAndroidNotification(req PushNotification) *fcm.Message {
 		Condition:             req.Condition,
 		CollapseKey:           req.CollapseKey,
 		ContentAvailable:      req.ContentAvailable,
+		MutableContent:        req.MutableContent,
 		DelayWhileIdle:        req.DelayWhileIdle,
 		TimeToLive:            req.TimeToLive,
 		RestrictedPackageName: req.RestrictedPackageName,

--- a/gorush/server_test.go
+++ b/gorush/server_test.go
@@ -231,7 +231,7 @@ func TestMutableContent(t *testing.T) {
 					"tokens":          []string{"aaaaa", "bbbbb"},
 					"platform":        PlatFormAndroid,
 					"message":         "Welcome",
-					"mutable-content": 1,
+					"mutable_content": 1,
 					"topic":           "test",
 					"badge":           1,
 					"alert": gofight.D{
@@ -242,7 +242,7 @@ func TestMutableContent(t *testing.T) {
 			},
 		}).
 		Run(routerEngine(), func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
-			// json: cannot unmarshal number into Go struct field PushNotification.mutable-content of type bool
+			// json: cannot unmarshal number into Go struct field PushNotification.mutable_content of type bool
 			assert.Equal(t, http.StatusBadRequest, r.Code)
 		})
 }

--- a/vendor/github.com/appleboy/go-fcm/README.md
+++ b/vendor/github.com/appleboy/go-fcm/README.md
@@ -1,10 +1,10 @@
 # go-fcm
 
-[![GoDoc](https://godoc.org/github.com/appleboy/go-fcm?status.svg)](https://godoc.org/github.com/edganiukov/fcm)
-[![Build Status](https://travis-ci.org/appleboy/go-fcm.svg?branch=master)](https://travis-ci.org/edganiukov/fcm)
-[![Go Report Card](https://goreportcard.com/badge/github.com/appleboy/go-fcm)](https://goreportcard.com/report/github.com/edganiukov/fcm)
+[![GoDoc](https://godoc.org/github.com/appleboy/go-fcm?status.svg)](https://godoc.org/github.com/appleboy/go-fcm)
+[![Build Status](https://travis-ci.org/appleboy/go-fcm.svg?branch=master)](https://travis-ci.org/appleboy/go-fcm)
+[![Go Report Card](https://goreportcard.com/badge/github.com/appleboy/go-fcm)](https://goreportcard.com/report/github.com/appleboy/go-fcmm)
 
-This project was forked from [github.com/edganiukov/fcmfcm](https://github.com/edganiukov/fcm).
+This project was forked from [github.com/edganiukov/fcm](https://github.com/edganiukov/fcm).
 
 Golang client library for Firebase Cloud Messaging. Implemented only [HTTP client](https://firebase.google.com/docs/cloud-messaging/http-server-ref#downstream).
 

--- a/vendor/github.com/appleboy/go-fcm/message.go
+++ b/vendor/github.com/appleboy/go-fcm/message.go
@@ -24,6 +24,7 @@ var (
 type Notification struct {
 	Title        string `json:"title,omitempty"`
 	Body         string `json:"body,omitempty"`
+	ChannelId    string `json:"android_channel_id, omitempty"`
 	Icon         string `json:"icon,omitempty"`
 	Sound        string `json:"sound,omitempty"`
 	Badge        string `json:"badge,omitempty"`
@@ -45,6 +46,7 @@ type Message struct {
 	CollapseKey              string                 `json:"collapse_key,omitempty"`
 	Priority                 string                 `json:"priority,omitempty"`
 	ContentAvailable         bool                   `json:"content_available,omitempty"`
+	MutableContent           bool                   `json:"mutable_content,omitempty"`
 	DelayWhileIdle           bool                   `json:"delay_while_idle,omitempty"`
 	TimeToLive               *uint                  `json:"time_to_live,omitempty"`
 	DeliveryReceiptRequested bool                   `json:"delivery_receipt_requested,omitempty"`

--- a/vendor/github.com/appleboy/go-fcm/message.go
+++ b/vendor/github.com/appleboy/go-fcm/message.go
@@ -45,7 +45,6 @@ type Message struct {
 	CollapseKey              string                 `json:"collapse_key,omitempty"`
 	Priority                 string                 `json:"priority,omitempty"`
 	ContentAvailable         bool                   `json:"content_available,omitempty"`
-	MutableContent           bool                   `json:"mutable_content,omitempty"`
 	DelayWhileIdle           bool                   `json:"delay_while_idle,omitempty"`
 	TimeToLive               *uint                  `json:"time_to_live,omitempty"`
 	DeliveryReceiptRequested bool                   `json:"delivery_receipt_requested,omitempty"`

--- a/vendor/github.com/appleboy/go-fcm/message.go
+++ b/vendor/github.com/appleboy/go-fcm/message.go
@@ -45,6 +45,7 @@ type Message struct {
 	CollapseKey              string                 `json:"collapse_key,omitempty"`
 	Priority                 string                 `json:"priority,omitempty"`
 	ContentAvailable         bool                   `json:"content_available,omitempty"`
+	MutableContent           bool                   `json:"mutable_content,omitempty"`
 	DelayWhileIdle           bool                   `json:"delay_while_idle,omitempty"`
 	TimeToLive               *uint                  `json:"time_to_live,omitempty"`
 	DeliveryReceiptRequested bool                   `json:"delivery_receipt_requested,omitempty"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,12 +21,10 @@
 			"revisionTime": "2018-04-10T03:06:38Z"
 		},
 		{
-			"checksumSHA1": "1Jql7x7zDOmbDxGr4gsa8rFEC5g=",
+			"checksumSHA1": "gm1OOCOLjT16sLsu2jyvpXksx20=",
 			"path": "github.com/appleboy/go-fcm",
-			"revision": "3bc382cee4180b7e4753761fda69a003de97b0e9",
-			"revisionTime": "2017-10-25T02:33:50Z",
-			"version": "0.1.1",
-			"versionExact": "0.1.1"
+			"revision": "834eba2ee169f0930af5b355519f22f908cf3e49",
+			"revisionTime": "2018-08-14T17:09:15Z"
 		},
 		{
 			"checksumSHA1": "Ab7MUtqX0iq2PUzzBxWpgzPSydw=",


### PR DESCRIPTION
It is now possible to send `mutable_content` option to Firebase which gets forwarded as `mutable-content` option for APNS.

A link to official documentation is: https://firebase.google.com/docs/cloud-messaging/http-server-ref#mutable_content