### PR TITLE
gorush: do less copying in queueNotification

### DIFF
--- a/gorush/worker.go
+++ b/gorush/worker.go
@@ -34,8 +34,9 @@ func startWorker() {
 func queueNotification(req RequestPush) (int, []LogPushEntry) {
 	var count int
 	wg := sync.WaitGroup{}
-	newNotification := []PushNotification{}
-	for _, notification := range req.Notifications {
+	newNotification := []*PushNotification{}
+	for i := range req.Notifications {
+		notification := &req.Notifications[i]
 		switch notification.Platform {
 		case PlatFormIos:
 			if !PushConf.Ios.Enabled {
@@ -56,7 +57,7 @@ func queueNotification(req RequestPush) (int, []LogPushEntry) {
 			notification.log = &log
 			notification.AddWaitCount()
 		}
-		QueueNotification <- notification
+		QueueNotification <- *notification
 		count += len(notification.Tokens)
 		// Count topic message
 		if notification.To != "" {


### PR DESCRIPTION
The PushNotification object is quite big (772 bytes on AMD64),
so avoid doing too many copying without a need.

Collect pointers and do copying only when sending into a channel.

Found using https://go-critic.github.io/overview#rangeValCopy-ref

Linter output:
```
$GOPATH/src/github.com/appleboy/gorush/gorush/worker.go:38:2: rangeValCopy: each iteration copies 772 bytes (consider pointers or indexing)
$GOPATH/src/github.com/appleboy/gorush/gorush/worker.go:53:2: rangeValCopy: each iteration copies 772 bytes (consider pointers or indexing)
```