### PR TITLE
fixed: sound without a critical alert in ios push notifications

### DIFF
--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -204,6 +204,9 @@ func GetIOSNotification(req PushNotification) *apns2.Notification {
 		result := &Sound{}
 		_ = mapstructure.Decode(req.Sound, &result)
 		payload.Sound(result)
+	// from http request binding for non critical alerts
+	case string:
+		payload.Sound(&req.Sound)
 	case Sound:
 		payload.Sound(&req.Sound)
 	}

--- a/gorush/notification_apns_test.go
+++ b/gorush/notification_apns_test.go
@@ -197,6 +197,25 @@ func TestIOSSoundAndVolume(t *testing.T) {
 	assert.Equal(t, 4.5, soundVolume)
 	assert.Equal(t, int64(3), soundCritical)
 	assert.Equal(t, "test", soundName)
+
+	req = PushNotification{
+		ApnsID:   test,
+		Topic:    test,
+		Priority: "normal",
+		Message:  message,
+		Sound:    "default",
+	}
+
+	notification = GetIOSNotification(req)
+	dump, _ = json.Marshal(notification.Payload)
+	data = []byte(string(dump))
+
+	if err := json.Unmarshal(data, &dat); err != nil {
+		panic(err)
+	}
+
+	soundName, _ = jsonparser.GetString(data, "aps", "sound")
+	assert.Equal(t, "default", soundName)
 }
 
 func TestIOSSummaryArg(t *testing.T) {


### PR DESCRIPTION
Currently the notification, if a sound is specified, will be converted into a critical notification. This behaviour occurs because the sideshow/apns2 package initializes a new sound-dict on `payload.SoundName()` and inserts the name into it. If the sound-key is specified as a dictionary, the alert will be seen as a critical alert according to the documentation [developer.apple.com/documentation/usernotifications](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943363).

In order to prevent the notification to get a critical one by specifying a sound, the sound name from the rest-API needs to be set as string to the sound-property of the payload for apns. This can be achieved by setting either the sound-key from the request to the sound property of the payload if it is a string or by setting the soundname-key from the request to the sound property without the usage of `payload.SoundName()`. For more consistency to the documentation, this pull request implements the variant, that the sound-key from the request is set as string into the sound-property of the apns-payload.