### PR TITLE
Adds QueueUsage to prometheus metrics (same as /api/stat/app)

### DIFF
--- a/gorush/metrics.go
+++ b/gorush/metrics.go
@@ -14,6 +14,7 @@ type Metrics struct {
 	IosError       *prometheus.Desc
 	AndroidSuccess *prometheus.Desc
 	AndroidError   *prometheus.Desc
+	QueueUsage     *prometheus.Desc
 }
 
 // NewMetrics returns a new Metrics with all prometheus.Desc initialized
@@ -45,6 +46,11 @@ func NewMetrics() Metrics {
 			"Number of android fail count",
 			nil, nil,
 		),
+		QueueUsage: prometheus.NewDesc(
+			namespace+"queue_usage",
+			"Length of internal queue",
+			nil, nil,
+		),
 	}
 }
 
@@ -55,6 +61,7 @@ func (c Metrics) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.IosError
 	ch <- c.AndroidSuccess
 	ch <- c.AndroidError
+	ch <- c.QueueUsage
 }
 
 // Collect returns the metrics with values
@@ -83,5 +90,10 @@ func (c Metrics) Collect(ch chan<- prometheus.Metric) {
 		c.AndroidError,
 		prometheus.GaugeValue,
 		float64(StatStorage.GetAndroidError()),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.QueueUsage,
+		prometheus.GaugeValue,
+		float64(len(QueueNotification)),
 	)
 }


### PR DESCRIPTION
Exposes gorush_queue_usage metric to be used in prometheus so monitor internal queues

Useful to make sure we are coping well with traffic