### PR TITLE
feat: add tryEnqueue function.

### DIFF
--- a/gorush/notification_test.go
+++ b/gorush/notification_test.go
@@ -25,8 +25,6 @@ func TestCorrectConf(t *testing.T) {
 func TestSenMultipleNotifications(t *testing.T) {
 	PushConf, _ = config.LoadConf("")
 
-	InitWorkers(int64(2), 2)
-
 	PushConf.Ios.Enabled = true
 	PushConf.Ios.KeyPath = "../certificate/certificate-valid.pem"
 	err := InitAPNSClient()

--- a/gorush/worker_test.go
+++ b/gorush/worker_test.go
@@ -1,0 +1,17 @@
+package gorush
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTryEnqueue(t *testing.T) {
+	chn := make(chan PushNotification, 2)
+	assert.True(t, tryEnqueue(PushNotification{}, chn))
+	assert.Equal(t, 1, len(chn))
+	assert.True(t, tryEnqueue(PushNotification{}, chn))
+	assert.Equal(t, 2, len(chn))
+	assert.False(t, tryEnqueue(PushNotification{}, chn))
+	assert.Equal(t, 2, len(chn))
+}


### PR DESCRIPTION
tryEnqueue tries to enqueue a job to the given job channel. Returns true if
the operation was successful, and false if enqueuing would not have been
possible without blocking. Job is not enqueued in the latter case.

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>