### PR TITLE
Some improve

### DIFF
--- a/gorush/log.go
+++ b/gorush/log.go
@@ -95,7 +95,7 @@ func SetLogOut(log *logrus.Logger, outString string) error {
 	case "stderr":
 		log.Out = os.Stderr
 	default:
-		f, err := os.OpenFile(outString, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+		f, err := os.OpenFile(outString, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0600)
 
 		if err != nil {
 			return err

--- a/gorush/notification_fcm.go
+++ b/gorush/notification_fcm.go
@@ -186,9 +186,7 @@ Retry:
 	// Device Group HTTP Response
 	if len(res.FailedRegistrationIDs) > 0 {
 		isError = true
-		for _, id := range res.FailedRegistrationIDs {
-			newTokens = append(newTokens, id)
-		}
+		newTokens = append(newTokens, res.FailedRegistrationIDs...)
 
 		LogPush(FailedPush, notification.To, req, errors.New("device group: partial success or all fails"))
 		if PushConf.Core.Sync {

--- a/gorush/server_test.go
+++ b/gorush/server_test.go
@@ -139,7 +139,7 @@ func TestRootHandler(t *testing.T) {
 
 			assert.Equal(t, "Welcome to notification server.", value)
 			assert.Equal(t, http.StatusOK, r.Code)
-			assert.Equal(t, "application/json; charset=utf-8", r.HeaderMap["Content-Type"])
+			assert.Equal(t, "application/json; charset=utf-8", r.HeaderMap.Get("Content-Type"))
 		})
 }
 
@@ -199,7 +199,7 @@ func TestMissingNotificationsParameter(t *testing.T) {
 		Run(routerEngine(), func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 
 			assert.Equal(t, http.StatusBadRequest, r.Code)
-			assert.Equal(t, "application/json; charset=utf-8", r.HeaderMap["Content-Type"])
+			assert.Equal(t, "application/json; charset=utf-8", r.HeaderMap.Get("Content-Type"))
 		})
 }
 

--- a/gorush/server_test.go
+++ b/gorush/server_test.go
@@ -133,13 +133,13 @@ func TestRootHandler(t *testing.T) {
 
 	r.GET("/").
 		Run(routerEngine(), func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
-			data := []byte(r.Body.String())
+			data := r.Body.Bytes()
 
 			value, _ := jsonparser.GetString(data, "text")
 
 			assert.Equal(t, "Welcome to notification server.", value)
 			assert.Equal(t, http.StatusOK, r.Code)
-			assert.Equal(t, "application/json; charset=utf-8", r.HeaderMap.Get("Content-Type"))
+			assert.Equal(t, "application/json; charset=utf-8", r.HeaderMap["Content-Type"])
 		})
 }
 
@@ -150,7 +150,7 @@ func TestAPIStatusGoHandler(t *testing.T) {
 
 	r.GET("/api/stat/go").
 		Run(routerEngine(), func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
-			data := []byte(r.Body.String())
+			data := r.Body.Bytes()
 
 			value, _ := jsonparser.GetString(data, "go_version")
 
@@ -169,7 +169,7 @@ func TestAPIStatusAppHandler(t *testing.T) {
 
 	r.GET("/api/stat/app").
 		Run(routerEngine(), func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
-			data := []byte(r.Body.String())
+			data := r.Body.Bytes()
 
 			value, _ := jsonparser.GetString(data, "version")
 
@@ -199,7 +199,7 @@ func TestMissingNotificationsParameter(t *testing.T) {
 		Run(routerEngine(), func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 
 			assert.Equal(t, http.StatusBadRequest, r.Code)
-			assert.Equal(t, "application/json; charset=utf-8", r.HeaderMap.Get("Content-Type"))
+			assert.Equal(t, "application/json; charset=utf-8", r.HeaderMap["Content-Type"])
 		})
 }
 
@@ -346,7 +346,7 @@ func TestVersionHandler(t *testing.T) {
 	r.GET("/version").
 		Run(routerEngine(), func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 			assert.Equal(t, http.StatusOK, r.Code)
-			data := []byte(r.Body.String())
+			data := r.Body.Bytes()
 
 			value, _ := jsonparser.GetString(data, "version")
 


### PR DESCRIPTION
1. Use bytes.Buffer.String or bytes.Buffer.Bytes
2. Use a single append to concatenate two slices
3. Poor file permissions used when creating file or using chmod
4. Using a deprecated function, variable, constant or field

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>