### PR TITLE
When queue is full, requests hang because Wait.Done() is not called on the affected notification

### DIFF
--- a/gorush/worker.go
+++ b/gorush/worker.go
@@ -37,7 +37,7 @@ func markFailedNotification(notification *PushNotification, reason string) {
 	for _, token := range notification.Tokens {
 		notification.AddLog(getLogPushEntry(FailedPush, token, *notification, errors.New(reason)))
 	}
-	notification.wg.Done()
+	notification.WaitDone()
 }
 
 // queueNotification add notification to queue list.

--- a/gorush/worker.go
+++ b/gorush/worker.go
@@ -1,6 +1,7 @@
 package gorush
 
 import (
+	"errors"
 	"sync"
 )
 
@@ -28,6 +29,15 @@ func startWorker() {
 		notification := <-QueueNotification
 		SendNotification(notification)
 	}
+}
+
+// markFailedNotification adds failure logs for all tokens in push notification
+func markFailedNotification(notification *PushNotification, reason string) {
+	LogError.Error(reason)
+	for _, token := range notification.Tokens {
+		notification.AddLog(getLogPushEntry(FailedPush, token, *notification, errors.New(reason)))
+	}
+	notification.wg.Done()
 }
 
 // queueNotification add notification to queue list.
@@ -58,7 +68,7 @@ func queueNotification(req RequestPush) (int, []LogPushEntry) {
 			notification.AddWaitCount()
 		}
 		if !tryEnqueue(*notification, QueueNotification) {
-			LogError.Error("max capacity reached")
+			markFailedNotification(notification, "max capacity reached")
 		}
 		count += len(notification.Tokens)
 		// Count topic message


### PR DESCRIPTION
While testing a few scenarios I noticed that whenever tryEnqueue fails on a notification due to the queue not being available then the request will block on wg.Wait() in Sync mode which will lead the request to hang.
My proposed fix returns the failed notifications to the client so that it can act accordingly