### PR TITLE
Allow APNS expiration to be 0

### DIFF
--- a/gorush/notification.go
+++ b/gorush/notification.go
@@ -81,7 +81,7 @@ type PushNotification struct {
 	Notification          fcm.Notification `json:"notification,omitempty"`
 
 	// iOS
-	Expiration  int64    `json:"expiration,omitempty"`
+	Expiration  *int64   `json:"expiration,omitempty"`
 	ApnsID      string   `json:"apns_id,omitempty"`
 	CollapseID  string   `json:"collapse_id,omitempty"`
 	Topic       string   `json:"topic,omitempty"`

--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -175,8 +175,8 @@ func GetIOSNotification(req PushNotification) *apns2.Notification {
 		CollapseID: req.CollapseID,
 	}
 
-	if req.Expiration > 0 {
-		notification.Expiration = time.Unix(req.Expiration, 0)
+	if req.Expiration != nil {
+		notification.Expiration = time.Unix(*req.Expiration, 0)
 	}
 
 	if len(req.Priority) > 0 && req.Priority == "normal" {


### PR DESCRIPTION
0 is a valid value for APNS expiration, which dictates not to store the push notification. Currently setting it to 0, gorush drops the value as oppose to passing it on to APNS.

https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns