### PR TITLE
Update gofight, gin-status-api to fix build issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Sereal/Sereal v0.0.0-20190606082811-cf1bab6c7a3a // indirect
 	github.com/apex/gateway v1.1.1
 	github.com/appleboy/com v0.0.2
-	github.com/appleboy/gin-status-api v1.0.3
+	github.com/appleboy/gin-status-api v1.0.3-0.20200112153628-43a878e4f9ab
 	github.com/appleboy/go-fcm v0.1.4
 	github.com/appleboy/gofight/v2 v2.1.2
 	github.com/asdine/storm v2.1.2+incompatible

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/Sereal/Sereal v0.0.0-20190606082811-cf1bab6c7a3a // indirect
 	github.com/apex/gateway v1.1.1
 	github.com/appleboy/com v0.0.2
-	github.com/appleboy/gin-status-api v1.0.2
+	github.com/appleboy/gin-status-api v1.0.3
 	github.com/appleboy/go-fcm v0.1.4
-	github.com/appleboy/gofight/v2 v2.1.1
+	github.com/appleboy/gofight/v2 v2.1.2
 	github.com/asdine/storm v2.1.2+incompatible
 	github.com/aws/aws-lambda-go v1.13.3 // indirect
 	github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23


### PR DESCRIPTION
In reference to appleboy/gofight#79 and appleboy/gin-status-api/pull/6

_Hav'nt tested this change but v2.1.1 > v2.1.2 and v1.0.2 > v1.0.3 should be a simple bug fixes._
*appleboy/gin-status-api/pull/6 needs to be merged first*
