### PR TITLE
docs: fix minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ See the default [YAML config example](config/config.yml):
 [embedmd]:# (config/testdata/config.yml yaml)
 ```yaml
 core:
-  enabled: true # enabale httpd server
+  enabled: true # enable httpd server
   address: "" # ip address to bind (default: any)
   shutdown_timeout: 30 # default is 30 second
   port: "8088" # ignore this port number if auto_tls is enabled (listen 443).
@@ -121,7 +121,7 @@ core:
     host: "" # which domains the Let's Encrypt will attempt
 
 grpc:
-  enabled: false # enabale gRPC server
+  enabled: false # enable gRPC server
   port: 9000
 
 api:

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ import (
 
 var defaultConf = []byte(`
 core:
-  enabled: true # enabale httpd server
+  enabled: true # enable httpd server
   address: "" # ip address to bind (default: any)
   shutdown_timeout: 30 # default is 30 second
   port: "8088" # ignore this port number if auto_tls is enabled (listen 443).
@@ -39,7 +39,7 @@ core:
     host: "" # which domains the Let's Encrypt will attempt
 
 grpc:
-  enabled: false # enabale gRPC server
+  enabled: false # enable gRPC server
   port: 9000
 
 api:

--- a/config/testdata/config.yml
+++ b/config/testdata/config.yml
@@ -1,5 +1,5 @@
 core:
-  enabled: true # enabale httpd server
+  enabled: true # enable httpd server
   address: "" # ip address to bind (default: any)
   shutdown_timeout: 30 # default is 30 second
   port: "8088" # ignore this port number if auto_tls is enabled (listen 443).
@@ -26,7 +26,7 @@ core:
     host: "" # which domains the Let's Encrypt will attempt
 
 grpc:
-  enabled: false # enabale gRPC server
+  enabled: false # enable gRPC server
   port: 9000
 
 api:


### PR DESCRIPTION
This fixes a typo in "enable" in several places.