### PR TITLE
chore(http): ignore ErrServerClosed error

### DIFF
--- a/gorush/server_normal.go
+++ b/gorush/server_normal.go
@@ -81,7 +81,10 @@ func listenAndServe(ctx context.Context, s *http.Server) error {
 		}
 	})
 	g.Go(func() error {
-		return s.ListenAndServe()
+		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
 	})
 	return g.Wait()
 }
@@ -98,7 +101,10 @@ func listenAndServeTLS(ctx context.Context, s *http.Server) error {
 		}
 	})
 	g.Go(func() error {
-		return s.ListenAndServeTLS("", "")
+		if err := s.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
 	})
 	return g.Wait()
 }


### PR DESCRIPTION
ignore ErrServerClosed err in graceful shutdown

`ErrServerClosed` is returned by the Server's Serve, ServeTLS, ListenAndServe,
and ListenAndServeTLS methods after a call to Shutdown or Close.

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>