### PR TITLE
Duplicate notification fix

### DIFF
--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -392,11 +391,7 @@ Retry:
 			deviceNotification.DeviceToken = token
 
 			// send ios notification
-			url := fmt.Sprintf("before .../3/device/%v", deviceNotification.DeviceToken)
-			fmt.Println(url)
 			res, err := client.Push(&deviceNotification)
-			url = fmt.Sprintf("after .../3/device/%v", deviceNotification.DeviceToken)
-			fmt.Println(url)
 
 			if err != nil || res.StatusCode != 200 {
 				if err == nil {

--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -388,13 +388,13 @@ Retry:
 		MaxConcurrentIOSPushes <- struct{}{}
 		wg.Add(1)
 		go func(token string) {
-			deviceNotification := baseNotification
+			deviceNotification := *baseNotification
 			deviceNotification.DeviceToken = token
 
 			// send ios notification
 			url := fmt.Sprintf("before .../3/device/%v", deviceNotification.DeviceToken)
 			fmt.Println(url)
-			res, err := client.Push(deviceNotification)
+			res, err := client.Push(&deviceNotification)
 			url = fmt.Sprintf("after .../3/device/%v", deviceNotification.DeviceToken)
 			fmt.Println(url)
 

--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -392,9 +392,11 @@ Retry:
 			deviceNotification.DeviceToken = token
 
 			// send ios notification
-			url := fmt.Sprintf(".../3/device/%v", deviceNotification.DeviceToken)
+			url := fmt.Sprintf("before .../3/device/%v", deviceNotification.DeviceToken)
 			fmt.Println(url)
 			res, err := client.Push(deviceNotification)
+			url = fmt.Sprintf("after .../3/device/%v", deviceNotification.DeviceToken)
+			fmt.Println(url)
 
 			if err != nil || res.StatusCode != 200 {
 				if err == nil {

--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -420,9 +420,7 @@ Retry:
 					newTokens = append(newTokens, token)
 				}
 				isError = true
-			}
-
-			if res.Sent() && !isError {
+			} else if res.Sent() {
 				LogPush(SucceededPush, token, req, nil)
 				StatStorage.AddIosSuccess(1)
 			}

--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -378,7 +378,7 @@ Retry:
 		newTokens []string
 	)
 
-	notification := GetIOSNotification(req)
+	baseNotification := GetIOSNotification(req)
 	client := getApnsClient(req)
 
 	var wg sync.WaitGroup
@@ -387,10 +387,11 @@ Retry:
 		MaxConcurrentIOSPushes <- struct{}{}
 		wg.Add(1)
 		go func(token string) {
-			notification.DeviceToken = token
+			deviceNotification := baseNotification
+			deviceNotification.DeviceToken = token
 
 			// send ios notification
-			res, err := client.Push(notification)
+			res, err := client.Push(deviceNotification)
 
 			if err != nil || res.StatusCode != 200 {
 				if err == nil {

--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -431,7 +431,7 @@ Retry:
 	}
 	wg.Wait()
 
-	if isError && retryCount < maxRetry {
+	if len(newTokens) > 0 && retryCount < maxRetry {
 		retryCount++
 
 		// resend fail token

--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -391,6 +392,8 @@ Retry:
 			deviceNotification.DeviceToken = token
 
 			// send ios notification
+			url := fmt.Sprintf(".../3/device/%v", deviceNotification.DeviceToken)
+			fmt.Println(url)
 			res, err := client.Push(deviceNotification)
 
 			if err != nil || res.StatusCode != 200 {


### PR DESCRIPTION
Resolves a concurrency issue which resulted in duplicate notifications being delivered to some devices and other not receiving theirs, when processing a batch of new notifications.