### PR TITLE
fix(k8s): update the manifests for k8s 1.18

### DIFF
--- a/k8s/gorush-deployment.yaml
+++ b/k8s/gorush-deployment.yaml
@@ -1,10 +1,14 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gorush
   namespace: gorush
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: gorush
+      tier: frontend
   template:
     metadata:
       labels:

--- a/k8s/gorush-redis-deployment.yaml
+++ b/k8s/gorush-redis-deployment.yaml
@@ -1,9 +1,14 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis
   namespace: gorush
 spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
   replicas: 1
   template:
     metadata:

--- a/k8s/gorush-service.yaml
+++ b/k8s/gorush-service.yaml
@@ -12,8 +12,13 @@ spec:
     tier: frontend
   # if your cluster supports it, uncomment the following to automatically create
   # an external load-balanced IP for the frontend service.
-  type: LoadBalancer
+  # type: LoadBalancer
+  #
+  # if you want to expose the service to the outside (without a load balancer in front)
   # type: NodePort
+  #
+  # if you want gorush to be accessible only within the cluster
+  # type: ClusterIP
   ports:
   - protocol: TCP
     port: 80


### PR DESCRIPTION
Deployments are now in "apps/v1", and require a matchLabel selector.