### PR TITLE
Enable sending notifications via gRPC to FCM topic 

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -68,6 +68,10 @@ func (s *Server) Send(ctx context.Context, in *proto.NotificationRequest) (*prot
 		notification.Badge = &badge
 	}
 
+	if in.Topic != "" && in.Platform == gorush.PlatFormAndroid {
+		notification.To = in.Topic
+	}
+
 	if in.Alert != nil {
 		notification.Alert = gorush.Alert{
 			Title:        in.Alert.Title,


### PR DESCRIPTION
In order to be able to send notifications to FCM topics via gRPC, copy `PushNotification.Topic` to `PushNotification.To` field for android

Fixed #528 