### PR TITLE
fix(push): goroutine leak

### DIFF
--- a/gorush/notification_hms.go
+++ b/gorush/notification_hms.go
@@ -159,7 +159,7 @@ func GetHuaweiNotification(req PushNotification) (*model.MessageRequest, error) 
 		return nil, err
 	}
 
-	LogAccess.Debug("Default message is %s", string(b))
+	LogAccess.Debugf("Default message is %s", string(b))
 	return msgRequest, nil
 }
 

--- a/gorush/server.go
+++ b/gorush/server.go
@@ -79,16 +79,18 @@ func pushHandler(c *gin.Context) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	notifier := c.Writer.CloseNotify()
 	go func(closer <-chan bool) {
-		<-closer
+		// Deprecated: the CloseNotifier interface predates Go's context package.
+		// New code should use Request.Context instead.
+		// Change to context package
+		<-c.Request.Context().Done()
 		// Don't send notification after client timeout or disconnected.
 		// See the following issue for detail information.
 		// https://github.com/appleboy/gorush/issues/422
 		if PushConf.Core.Sync {
 			cancel()
 		}
-	}(notifier)
+	}()
 
 	counts, logs := queueNotification(ctx, form)
 

--- a/gorush/server.go
+++ b/gorush/server.go
@@ -79,7 +79,7 @@ func pushHandler(c *gin.Context) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go func(closer <-chan bool) {
+	go func() {
 		// Deprecated: the CloseNotifier interface predates Go's context package.
 		// New code should use Request.Context instead.
 		// Change to context package

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -63,7 +63,7 @@ func (s *Server) Send(ctx context.Context, in *proto.NotificationRequest) (*prot
 		ThreadID:         in.ThreadID,
 		MutableContent:   in.MutableContent,
 		Image:            in.Image,
-		Priority: strings.ToLower(in.GetPriority().String()),
+		Priority:         strings.ToLower(in.GetPriority().String()),
 	}
 
 	if badge > 0 {


### PR DESCRIPTION
// Deprecated: the CloseNotifier interface predates Go's context package.
// New code should use Request.Context instead.

https://golang.org/src/net/http/server.go

fixed #518 

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>