### PR TITLE
Improve observability on FCM errors

### DIFF
--- a/gorush/notification_fcm_test.go
+++ b/gorush/notification_fcm_test.go
@@ -102,6 +102,7 @@ func TestPushToAndroidRightTokenForStringLog(t *testing.T) {
 func TestOverwriteAndroidAPIKey(t *testing.T) {
 	PushConf, _ = config.LoadConf("")
 
+	PushConf.Core.Sync = true
 	PushConf.Android.Enabled = true
 	PushConf.Android.APIKey = os.Getenv("ANDROID_API_KEY")
 
@@ -113,10 +114,14 @@ func TestOverwriteAndroidAPIKey(t *testing.T) {
 		Message:  "Welcome",
 		// overwrite android api key
 		APIKey: "1234",
+
+		log: &[]LogPushEntry{},
 	}
 
 	// FCM server error: 401 error: 401 Unauthorized (Wrong API Key)
 	PushToAndroid(req)
+
+	assert.Len(t, *req.log, 2)
 }
 
 func TestFCMMessage(t *testing.T) {


### PR DESCRIPTION
When an error returned from FCM (e.g. 401 Unauthorized) or connectivity issues between gorush and FCM server occurs, gorush outputs the error on logs, but a caller cannot observe it. Gorush never return the error to the caller on HTTP response, and also we cannot obtain it by via metrics (stat API).

This change makes a caller to able to observe an error returned from FCM.