### PR TITLE
Gorush crashes with a invalid feedback URL

### DIFF
--- a/gorush/feedback.go
+++ b/gorush/feedback.go
@@ -22,7 +22,11 @@ func DispatchFeedback(log LogPushEntry, url string, timeout int64) error {
 		return err
 	}
 
-	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+	if err != nil {
+		return err
+	}
+
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
 	var transport = &http.Transport{


### PR DESCRIPTION
`http.NewRequest()` may return a nil req and an error when given an invalid URL.  It can occurs nil-pointer dereference on creating a feedback request.

To reproduce it:

1. Make `feedback_hook_url` invalid, and run gorush with the config:
    ```yaml
    ...
    core:
      sync: false
      feedback_hook_url: "127.0.0.1:12345"  # first path segment in URL cannot contain colon
    ...
    ```
2. Send a push to gorush:

    ```console
    $ curl http://127.0.0.1:8088/api/push -d '{
      "notifications": [
        {
          "tokens": ["*"],
          "platform": 2,
          "message": "Hello World Android!"
        }
      ]
    }'
    ```

3.  Gorush dies with a nil pointer dereference error
    ```
    ERRO[2020/10/07 - 07:00:14] | failed-push | android [*] | Hello World Android! | Error Message: invalid registration token
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x493dbc6]

    goroutine 121 [running]:
    github.com/appleboy/gorush/gorush.DispatchFeedback(0x0, 0x0, 0x4cfbcc9, 0xb, 0x4cf818a, 0x7, 0xc000d8f96f, 0x1, 0xc000baa780, 0x14, ...)
            gorush/feedback.go:30 +0x1a6
    github.com/appleboy/gorush/gorush.PushToAndroid.func1(0xc0004c8230, 0x0, 0x0, 0x4cfbcc9, 0xb, 0x4cf818a, 0x7, 0xc000d8f96f, 0x1, 0xc000baa780, ...)
            gorush/notification_fcm.go:176 +0x7f
    created by github.com/appleboy/gorush/gorush.PushToAndroid
            gorush/notification_fcm.go:175 +0xf09
    ```