### PR TITLE
iOS: Allow message and title to be used together, without using the alert-payload

### DIFF
--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -201,6 +201,10 @@ func iosAlertDictionary(payload *payload.Payload, req PushNotification) *payload
 		payload.AlertTitle(req.Title)
 	}
 
+	if len(req.Message) > 0 && len(req.Title) > 0 {
+		payload.AlertBody(req.Message)
+	}
+
 	if len(req.Alert.Title) > 0 {
 		payload.AlertTitle(req.Alert.Title)
 	}
@@ -286,8 +290,8 @@ func GetIOSNotification(req PushNotification) *apns2.Notification {
 
 	payload := payload.NewPayload()
 
-	// add alert object if message length > 0
-	if len(req.Message) > 0 {
+	// add alert object if message length > 0 and title length == 0
+	if len(req.Message) > 0 && len(req.Title) == 0 {
 		payload.Alert(req.Message)
 	}
 

--- a/gorush/notification_apns_test.go
+++ b/gorush/notification_apns_test.go
@@ -461,7 +461,7 @@ func TestMessageAndTitle(t *testing.T) {
 		Topic:            test,
 		Priority:         "normal",
 		Message:          message,
-		Title: 						title,
+		Title:            title,
 		ContentAvailable: true,
 	}
 

--- a/gorush/notification_apns_test.go
+++ b/gorush/notification_apns_test.go
@@ -476,18 +476,18 @@ func TestMessageAndTitle(t *testing.T) {
 	}
 
 	alert, _ := jsonparser.GetString(data, "aps", "alert")
-	alert_body, _ := jsonparser.GetString(data, "aps", "alert", "body")
-	alert_title, _ := jsonparser.GetString(data, "aps", "alert", "title")
+	alertBody, _ := jsonparser.GetString(data, "aps", "alert", "body")
+	alertTitle, _ := jsonparser.GetString(data, "aps", "alert", "title")
 
 	assert.Equal(t, test, notification.ApnsID)
 	assert.Equal(t, ApnsPriorityLow, notification.Priority)
-	assert.Equal(t, message, alert_body)
-	assert.Equal(t, title, alert_title)
+	assert.Equal(t, message, alertBody)
+	assert.Equal(t, title, alertTitle)
 	assert.NotEqual(t, message, alert)
 
 	// Add alert body
-	message_override := "Welcome notification Server overridden"
-	req.Alert.Body = message_override
+	messageOverride := "Welcome notification Server overridden"
+	req.Alert.Body = messageOverride
 
 	notification = GetIOSNotification(req)
 
@@ -499,11 +499,11 @@ func TestMessageAndTitle(t *testing.T) {
 		panic(err)
 	}
 
-	alert_body_overridden, _ := jsonparser.GetString(data, "aps", "alert", "body")
-	alert_title, _ = jsonparser.GetString(data, "aps", "alert", "title")
-	assert.Equal(t, message_override, alert_body_overridden)
-	assert.NotEqual(t, message, alert_body_overridden)
-	assert.Equal(t, title, alert_title)
+	alertBodyOverridden, _ := jsonparser.GetString(data, "aps", "alert", "body")
+	alertTitle, _ = jsonparser.GetString(data, "aps", "alert", "title")
+	assert.Equal(t, messageOverride, alertBodyOverridden)
+	assert.NotEqual(t, message, alertBodyOverridden)
+	assert.Equal(t, title, alertTitle)
 }
 
 func TestIOSAlertNotificationStructure(t *testing.T) {

--- a/gorush/notification_apns_test.go
+++ b/gorush/notification_apns_test.go
@@ -450,6 +450,62 @@ func TestAlertStringExample3ForIos(t *testing.T) {
 	assert.Equal(t, test, dat["aps"].(map[string]interface{})["alert"])
 }
 
+func TestMessageAndTitle(t *testing.T) {
+	var dat map[string]interface{}
+
+	test := "test"
+	message := "Welcome notification Server"
+	title := "Welcome notification Server title"
+	req := PushNotification{
+		ApnsID:           test,
+		Topic:            test,
+		Priority:         "normal",
+		Message:          message,
+		Title: 						title,
+		ContentAvailable: true,
+	}
+
+	notification := GetIOSNotification(req)
+
+	dump, _ := json.Marshal(notification.Payload)
+	data := []byte(string(dump))
+
+	if err := json.Unmarshal(data, &dat); err != nil {
+		log.Println(err)
+		panic(err)
+	}
+
+	alert, _ := jsonparser.GetString(data, "aps", "alert")
+	alert_body, _ := jsonparser.GetString(data, "aps", "alert", "body")
+	alert_title, _ := jsonparser.GetString(data, "aps", "alert", "title")
+
+	assert.Equal(t, test, notification.ApnsID)
+	assert.Equal(t, ApnsPriorityLow, notification.Priority)
+	assert.Equal(t, message, alert_body)
+	assert.Equal(t, title, alert_title)
+	assert.NotEqual(t, message, alert)
+
+	// Add alert body
+	message_override := "Welcome notification Server overridden"
+	req.Alert.Body = message_override
+
+	notification = GetIOSNotification(req)
+
+	dump, _ = json.Marshal(notification.Payload)
+	data = []byte(string(dump))
+
+	if err := json.Unmarshal(data, &dat); err != nil {
+		log.Println(err)
+		panic(err)
+	}
+
+	alert_body_overridden, _ := jsonparser.GetString(data, "aps", "alert", "body")
+	alert_title, _ = jsonparser.GetString(data, "aps", "alert", "title")
+	assert.Equal(t, message_override, alert_body_overridden)
+	assert.NotEqual(t, message, alert_body_overridden)
+	assert.Equal(t, title, alert_title)
+}
+
 func TestIOSAlertNotificationStructure(t *testing.T) {
 	var dat map[string]interface{}
 


### PR DESCRIPTION
This PR will allow callers to use the `Message` & `Title` without the need of setting any values in the alert-payload, essentially making it easier to build cross-device-push for regular title+message pushes on different platforms.

This will not per-se break anything, just allow a broader use-case of the API.