### PR TITLE
Improve APNs http2 connection health check

### DIFF
--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -118,7 +118,7 @@ func InitAPNSClient() error {
 		}
 
 		if h2Transport, ok := ApnsClient.HTTPClient.Transport.(*http2.Transport); ok {
-			configureHttp2ConnHealthCheck(h2Transport)
+			configureHTTP2ConnHealthCheck(h2Transport)
 		}
 
 		if err != nil {
@@ -162,7 +162,7 @@ func newApnsClient(certificate tls.Certificate) (*apns2.Client, error) {
 	if h2Transport, err := http2.ConfigureTransports(transport); err != nil {
 		return nil, err
 	} else {
-		configureHttp2ConnHealthCheck(h2Transport)
+		configureHTTP2ConnHealthCheck(h2Transport)
 	}
 	client.HTTPClient.Transport = transport
 
@@ -191,7 +191,7 @@ func newApnsTokenClient(token *token.Token) (*apns2.Client, error) {
 	if h2Transport, err := http2.ConfigureTransports(transport); err != nil {
 		return nil, err
 	} else {
-		configureHttp2ConnHealthCheck(h2Transport)
+		configureHTTP2ConnHealthCheck(h2Transport)
 	}
 
 	client.HTTPClient.Transport = transport
@@ -199,7 +199,7 @@ func newApnsTokenClient(token *token.Token) (*apns2.Client, error) {
 	return client, nil
 }
 
-func configureHttp2ConnHealthCheck(h2Transport *http2.Transport) {
+func configureHTTP2ConnHealthCheck(h2Transport *http2.Transport) {
 	h2Transport.ReadIdleTimeout = 1 * time.Second
 	h2Transport.PingTimeout = 1 * time.Second
 }

--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -117,6 +117,10 @@ func InitAPNSClient() error {
 			ApnsClient, err = newApnsClient(certificateKey)
 		}
 
+		if h2Transport, ok := ApnsClient.HTTPClient.Transport.(*http2.Transport); ok {
+			configureHttp2ConnHealthCheck(h2Transport)
+		}
+
 		if err != nil {
 			LogError.Error("Transport Error:", err.Error())
 
@@ -155,11 +159,11 @@ func newApnsClient(certificate tls.Certificate) (*apns2.Client, error) {
 		IdleConnTimeout: idleConnTimeout,
 	}
 
-	transportErr := http2.ConfigureTransport(transport)
-	if transportErr != nil {
-		return nil, transportErr
+	if h2Transport, err := http2.ConfigureTransports(transport); err != nil {
+		return nil, err
+	} else {
+		configureHttp2ConnHealthCheck(h2Transport)
 	}
-
 	client.HTTPClient.Transport = transport
 
 	return client, nil
@@ -184,14 +188,20 @@ func newApnsTokenClient(token *token.Token) (*apns2.Client, error) {
 		IdleConnTimeout: idleConnTimeout,
 	}
 
-	transportErr := http2.ConfigureTransport(transport)
-	if transportErr != nil {
-		return nil, transportErr
+	if h2Transport, err := http2.ConfigureTransports(transport); err != nil {
+		return nil, err
+	} else {
+		configureHttp2ConnHealthCheck(h2Transport)
 	}
 
 	client.HTTPClient.Transport = transport
 
 	return client, nil
+}
+
+func configureHttp2ConnHealthCheck(h2Transport *http2.Transport) {
+	h2Transport.ReadIdleTimeout = 1 * time.Second
+	h2Transport.PingTimeout = 1 * time.Second
 }
 
 func iosAlertDictionary(payload *payload.Payload, req PushNotification) *payload.Payload {


### PR DESCRIPTION
From [Best Practices for Managing Connections](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html),

> You can check the health of your connection using an HTTP/2 PING frame.

And I happened when gorush try to send push to APNs, But cached http/2
connection is not available.Therefore I thik it is good that gorush
check APN/2 connection availability by HTTP/2 PING frame.

Here is a test code in local. With environment variable `GODEBUG=http2debug=2`, you can see a ping/2 log.

```golang
func TestHTTP2Ping(t *testing.T) {
	PushConf.Ios.Enabled = true
	PushConf.Ios.KeyPath = "../certificate/authkey-valid.p8"
	PushConf.Ios.TeamID = "example.team"
	PushConf.Ios.KeyID = "example.key"
	PushConf.Core.HTTPProxy = ""
	err := InitAPNSClient()
	assert.Nil(t, err)
	assert.Equal(t, apns2.HostDevelopment, ApnsClient.Host)

	for i := 1; i <= 10; i++ {
		if resp, err := ApnsClient.HTTPClient.Head(apns2.HostDevelopment); err != nil {
			t.Fatal(err)
		} else {
			assert.Equal(t, 405, resp.StatusCode)
			time.Sleep(time.Second * 10)
		}
	}
}
```

Ping log looks like below:

```
2021/05/04 17:17:20 http2: Framer 0xc0015d49a0: wrote PING len=8 ping="F\x9a\x11\x9b\xb7\x17\v*"
2021/05/04 17:17:20 http2: Framer 0xc0015d49a0: read PING flags=ACK len=8 ping="F\x9a\x11\x9b\xb7\x17\v*"
2021/05/04 17:17:20 http2: Transport received PING flags=ACK len=8 ping="F\x9a\x11\x9b\xb7\x17\v*"
2021/05/04 17:17:21 http2: Framer 0xc0015d49a0: wrote PING len=8 ping="\x05\xf1\xb8PP\xcdp\x99"
2021/05/04 17:17:21 http2: Framer 0xc0015d49a0: read PING flags=ACK len=8 ping="\x05\xf1\xb8PP\xcdp\x99"
2021/05/04 17:17:21 http2: Transport received PING flags=ACK len=8 ping="\x05\xf1\xb8PP\xcdp\x99"
```