### PR TITLE
Change metric type from Gauge to Counter

### DIFF
--- a/gorush/metrics.go
+++ b/gorush/metrics.go
@@ -116,7 +116,7 @@ func (c Metrics) Collect(ch chan<- prometheus.Metric) {
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.QueueUsage,
-		prometheus.CounterValue,
+		prometheus.GaugeValue,
 		float64(len(QueueNotification)),
 	)
 }

--- a/gorush/metrics.go
+++ b/gorush/metrics.go
@@ -81,42 +81,42 @@ func (c Metrics) Describe(ch chan<- *prometheus.Desc) {
 func (c Metrics) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
 		c.TotalPushCount,
-		prometheus.GaugeValue,
+		prometheus.CounterValue,
 		float64(StatStorage.GetTotalCount()),
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.IosSuccess,
-		prometheus.GaugeValue,
+		prometheus.CounterValue,
 		float64(StatStorage.GetIosSuccess()),
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.IosError,
-		prometheus.GaugeValue,
+		prometheus.CounterValue,
 		float64(StatStorage.GetIosError()),
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.AndroidSuccess,
-		prometheus.GaugeValue,
+		prometheus.CounterValue,
 		float64(StatStorage.GetAndroidSuccess()),
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.AndroidError,
-		prometheus.GaugeValue,
+		prometheus.CounterValue,
 		float64(StatStorage.GetAndroidError()),
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.HuaweiSuccess,
-		prometheus.GaugeValue,
+		prometheus.CounterValue,
 		float64(StatStorage.GetHuaweiSuccess()),
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.HuaweiError,
-		prometheus.GaugeValue,
+		prometheus.CounterValue,
 		float64(StatStorage.GetHuaweiError()),
 	)
 	ch <- prometheus.MustNewConstMetric(
 		c.QueueUsage,
-		prometheus.GaugeValue,
+		prometheus.CounterValue,
 		float64(len(QueueNotification)),
 	)
 }

--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -161,9 +161,10 @@ func newApnsClient(certificate tls.Certificate) (*apns2.Client, error) {
 
 	if h2Transport, err := http2.ConfigureTransports(transport); err != nil {
 		return nil, err
-	} else {
-		configureHTTP2ConnHealthCheck(h2Transport)
 	}
+
+	configureHTTP2ConnHealthCheck(h2Transport)
+
 	client.HTTPClient.Transport = transport
 
 	return client, nil
@@ -190,9 +191,9 @@ func newApnsTokenClient(token *token.Token) (*apns2.Client, error) {
 
 	if h2Transport, err := http2.ConfigureTransports(transport); err != nil {
 		return nil, err
-	} else {
-		configureHTTP2ConnHealthCheck(h2Transport)
 	}
+
+	configureHTTP2ConnHealthCheck(h2Transport)
 
 	client.HTTPClient.Transport = transport
 

--- a/gorush/notification_apns.go
+++ b/gorush/notification_apns.go
@@ -159,7 +159,8 @@ func newApnsClient(certificate tls.Certificate) (*apns2.Client, error) {
 		IdleConnTimeout: idleConnTimeout,
 	}
 
-	if h2Transport, err := http2.ConfigureTransports(transport); err != nil {
+	h2Transport, err := http2.ConfigureTransports(transport)
+	if err != nil {
 		return nil, err
 	}
 
@@ -189,7 +190,8 @@ func newApnsTokenClient(token *token.Token) (*apns2.Client, error) {
 		IdleConnTimeout: idleConnTimeout,
 	}
 
-	if h2Transport, err := http2.ConfigureTransports(transport); err != nil {
+	h2Transport, err := http2.ConfigureTransports(transport)
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Currently the metrics leveraged are of a gauge type, even though they are presenting counter data (monotonically increasing values) which can then have the family of `rate()` functions applied to extract instantaneous and trend data.