### PR TITLE
fix: Function params involve heavy amount of copying

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -276,8 +276,8 @@ type SectionGRPC struct {
 }
 
 // LoadConf load config from file and read in environment variables that match
-func LoadConf(confPath ...string) (ConfYaml, error) {
-	var conf ConfYaml
+func LoadConf(confPath ...string) (*ConfYaml, error) {
+	conf := &ConfYaml{}
 
 	viper.SetConfigType("yaml")
 	viper.AutomaticEnv()         // read in environment variables that match

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,8 +19,8 @@ func TestMissingFile(t *testing.T) {
 
 type ConfigTestSuite struct {
 	suite.Suite
-	ConfGorushDefault ConfYaml
-	ConfGorush        ConfYaml
+	ConfGorushDefault *ConfYaml
+	ConfGorush        *ConfYaml
 }
 
 func (suite *ConfigTestSuite) SetupTest() {

--- a/main.go
+++ b/main.go
@@ -459,7 +459,7 @@ func usage() {
 
 // handles pinging the endpoint and returns an error if the
 // agent is in an unhealthy state.
-func pinger(cfg config.ConfYaml) error {
+func pinger(cfg *config.ConfYaml) error {
 	transport := &http.Transport{
 		Dial: (&net.Dialer{
 			Timeout: 5 * time.Second,
@@ -481,7 +481,7 @@ func pinger(cfg config.ConfYaml) error {
 	return nil
 }
 
-func createPIDFile(cfg config.ConfYaml) error {
+func createPIDFile(cfg *config.ConfYaml) error {
 	if !cfg.Core.PID.Enabled {
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -194,7 +194,7 @@ func main() {
 	// send android notification
 	if opts.Android.Enabled {
 		cfg.Android.Enabled = opts.Android.Enabled
-		req := notify.PushNotification{
+		req := &notify.PushNotification{
 			Platform: core.PlatFormAndroid,
 			Message:  message,
 			Title:    title,
@@ -227,7 +227,7 @@ func main() {
 	// send huawei notification
 	if opts.Huawei.Enabled {
 		cfg.Huawei.Enabled = opts.Huawei.Enabled
-		req := notify.PushNotification{
+		req := &notify.PushNotification{
 			Platform: core.PlatFormHuawei,
 			Message:  message,
 			Title:    title,
@@ -264,7 +264,7 @@ func main() {
 		}
 
 		cfg.Ios.Enabled = opts.Ios.Enabled
-		req := notify.PushNotification{
+		req := &notify.PushNotification{
 			Platform: core.PlatFormIos,
 			Message:  message,
 			Title:    title,

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -142,7 +142,7 @@ func (p *PushNotification) IsTopic() bool {
 }
 
 // CheckMessage for check request message
-func CheckMessage(req PushNotification) error {
+func CheckMessage(req *PushNotification) error {
 	var msg string
 
 	// ignore send topic mesaage from FCM
@@ -243,11 +243,11 @@ func SendNotification(req queue.QueuedMessage, cfg *config.ConfYaml) (resp *Resp
 
 	switch v.Platform {
 	case core.PlatFormIos:
-		resp, err = PushToIOS(*v, cfg)
+		resp, err = PushToIOS(v, cfg)
 	case core.PlatFormAndroid:
-		resp, err = PushToAndroid(*v, cfg)
+		resp, err = PushToAndroid(v, cfg)
 	case core.PlatFormHuawei:
-		resp, err = PushToHuawei(*v, cfg)
+		resp, err = PushToHuawei(v, cfg)
 	}
 
 	if cfg.Core.FeedbackURL != "" {

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -195,7 +195,7 @@ func SetProxy(proxy string) error {
 }
 
 // CheckPushConf provide check your yml config.
-func CheckPushConf(cfg config.ConfYaml) error {
+func CheckPushConf(cfg *config.ConfYaml) error {
 	if !cfg.Ios.Enabled && !cfg.Android.Enabled && !cfg.Huawei.Enabled {
 		return errors.New("Please enable iOS, Android or Huawei config in yml config")
 	}
@@ -233,7 +233,7 @@ func CheckPushConf(cfg config.ConfYaml) error {
 }
 
 // SendNotification send notification
-func SendNotification(req queue.QueuedMessage, cfg config.ConfYaml) (resp *ResponsePush, err error) {
+func SendNotification(req queue.QueuedMessage, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
 	v, ok := req.(*PushNotification)
 	if !ok {
 		if err = json.Unmarshal(req.Bytes(), &v); err != nil {
@@ -263,7 +263,7 @@ func SendNotification(req queue.QueuedMessage, cfg config.ConfYaml) (resp *Respo
 }
 
 // Run send notification
-var Run = func(cfg config.ConfYaml) func(ctx context.Context, msg queue.QueuedMessage) error {
+var Run = func(cfg *config.ConfYaml) func(ctx context.Context, msg queue.QueuedMessage) error {
 	return func(ctx context.Context, msg queue.QueuedMessage) error {
 		_, err := SendNotification(msg, cfg)
 		return err

--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -217,7 +217,7 @@ func configureHTTP2ConnHealthCheck(h2Transport *http2.Transport) {
 	h2Transport.PingTimeout = 1 * time.Second
 }
 
-func iosAlertDictionary(payload *payload.Payload, req PushNotification) *payload.Payload {
+func iosAlertDictionary(payload *payload.Payload, req *PushNotification) *payload.Payload {
 	// Alert dictionary
 
 	if len(req.Title) > 0 {
@@ -288,7 +288,7 @@ func iosAlertDictionary(payload *payload.Payload, req PushNotification) *payload
 // GetIOSNotification use for define iOS notification.
 // The iOS Notification Payload
 // ref: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW1
-func GetIOSNotification(req PushNotification) *apns2.Notification {
+func GetIOSNotification(req *PushNotification) *apns2.Notification {
 	notification := &apns2.Notification{
 		ApnsID:     req.ApnsID,
 		Topic:      req.Topic,
@@ -371,7 +371,7 @@ func GetIOSNotification(req PushNotification) *apns2.Notification {
 	return notification
 }
 
-func getApnsClient(cfg *config.ConfYaml, req PushNotification) (client *apns2.Client) {
+func getApnsClient(cfg *config.ConfYaml, req *PushNotification) (client *apns2.Client) {
 	if req.Production {
 		client = ApnsClient.Production()
 	} else if req.Development {
@@ -387,7 +387,7 @@ func getApnsClient(cfg *config.ConfYaml, req PushNotification) (client *apns2.Cl
 }
 
 // PushToIOS provide send notification to APNs server.
-func PushToIOS(req PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
+func PushToIOS(req *PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
 	logx.LogAccess.Debug("Start push notification for iOS")
 
 	var (

--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -52,7 +52,7 @@ type Sound struct {
 }
 
 // InitAPNSClient use for initialize APNs Client.
-func InitAPNSClient(cfg config.ConfYaml) error {
+func InitAPNSClient(cfg *config.ConfYaml) error {
 	if cfg.Ios.Enabled {
 		var err error
 		var authKey *ecdsa.PrivateKey
@@ -141,7 +141,7 @@ func InitAPNSClient(cfg config.ConfYaml) error {
 	return nil
 }
 
-func newApnsClient(cfg config.ConfYaml, certificate tls.Certificate) (*apns2.Client, error) {
+func newApnsClient(cfg *config.ConfYaml, certificate tls.Certificate) (*apns2.Client, error) {
 	var client *apns2.Client
 
 	if cfg.Ios.Production {
@@ -181,7 +181,7 @@ func newApnsClient(cfg config.ConfYaml, certificate tls.Certificate) (*apns2.Cli
 	return client, nil
 }
 
-func newApnsTokenClient(cfg config.ConfYaml, token *token.Token) (*apns2.Client, error) {
+func newApnsTokenClient(cfg *config.ConfYaml, token *token.Token) (*apns2.Client, error) {
 	var client *apns2.Client
 
 	if cfg.Ios.Production {
@@ -371,7 +371,7 @@ func GetIOSNotification(req PushNotification) *apns2.Notification {
 	return notification
 }
 
-func getApnsClient(cfg config.ConfYaml, req PushNotification) (client *apns2.Client) {
+func getApnsClient(cfg *config.ConfYaml, req PushNotification) (client *apns2.Client) {
 	if req.Production {
 		client = ApnsClient.Production()
 	} else if req.Development {
@@ -387,7 +387,7 @@ func getApnsClient(cfg config.ConfYaml, req PushNotification) (client *apns2.Cli
 }
 
 // PushToIOS provide send notification to APNs server.
-func PushToIOS(req PushNotification, cfg config.ConfYaml) (resp *ResponsePush, err error) {
+func PushToIOS(req PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
 	logx.LogAccess.Debug("Start push notification for iOS")
 
 	var (

--- a/notify/notification_apns_test.go
+++ b/notify/notification_apns_test.go
@@ -59,7 +59,7 @@ func TestIOSNotificationStructure(t *testing.T) {
 	expectBadge := 0
 	message := "Welcome notification Server"
 	expiration := int64(time.Now().Unix())
-	req := PushNotification{
+	req := &PushNotification{
 		ApnsID:     test,
 		Topic:      test,
 		Expiration: &expiration,
@@ -124,7 +124,7 @@ func TestIOSSoundAndVolume(t *testing.T) {
 
 	test := "test"
 	message := "Welcome notification Server"
-	req := PushNotification{
+	req := &PushNotification{
 		ApnsID:   test,
 		Topic:    test,
 		Priority: "normal",
@@ -175,7 +175,7 @@ func TestIOSSoundAndVolume(t *testing.T) {
 	assert.Equal(t, int64(1), soundCritical)
 	assert.Equal(t, "foobar", soundName)
 
-	req = PushNotification{
+	req = &PushNotification{
 		ApnsID:   test,
 		Topic:    test,
 		Priority: "normal",
@@ -202,7 +202,7 @@ func TestIOSSoundAndVolume(t *testing.T) {
 	assert.Equal(t, int64(3), soundCritical)
 	assert.Equal(t, "test", soundName)
 
-	req = PushNotification{
+	req = &PushNotification{
 		ApnsID:   test,
 		Topic:    test,
 		Priority: "normal",
@@ -227,7 +227,7 @@ func TestIOSSummaryArg(t *testing.T) {
 
 	test := "test"
 	message := "Welcome notification Server"
-	req := PushNotification{
+	req := &PushNotification{
 		ApnsID:   test,
 		Topic:    test,
 		Priority: "normal",
@@ -261,7 +261,7 @@ func TestSendZeroValueForBadgeKey(t *testing.T) {
 
 	test := "test"
 	message := "Welcome notification Server"
-	req := PushNotification{
+	req := &PushNotification{
 		ApnsID:           test,
 		Topic:            test,
 		Priority:         "normal",
@@ -334,7 +334,7 @@ func TestCheckSilentNotification(t *testing.T) {
 	var dat map[string]interface{}
 
 	test := "test"
-	req := PushNotification{
+	req := &PushNotification{
 		ApnsID:           test,
 		Topic:            test,
 		CollapseID:       test,
@@ -381,7 +381,7 @@ func TestAlertStringExample2ForIos(t *testing.T) {
 	title := "Game Request"
 	body := "Bob wants to play poker"
 	actionLocKey := "PLAY"
-	req := PushNotification{
+	req := &PushNotification{
 		ApnsID:   test,
 		Topic:    test,
 		Priority: "normal",
@@ -424,7 +424,7 @@ func TestAlertStringExample3ForIos(t *testing.T) {
 	test := "test"
 	badge := 9
 	sound := "bingbong.aiff"
-	req := PushNotification{
+	req := &PushNotification{
 		ApnsID:           test,
 		Topic:            test,
 		Priority:         "normal",
@@ -455,7 +455,7 @@ func TestMessageAndTitle(t *testing.T) {
 	test := "test"
 	message := "Welcome notification Server"
 	title := "Welcome notification Server title"
-	req := PushNotification{
+	req := &PushNotification{
 		ApnsID:           test,
 		Topic:            test,
 		Priority:         "normal",
@@ -509,7 +509,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	var dat map[string]interface{}
 
 	test := "test"
-	req := PushNotification{
+	req := &PushNotification{
 		Message: "Welcome",
 		Title:   test,
 		Alert: Alert{
@@ -725,7 +725,7 @@ func TestPushToIOS(t *testing.T) {
 	err = status.InitAppStatus(cfg)
 	assert.Nil(t, err)
 
-	req := PushNotification{
+	req := &PushNotification{
 		Tokens:   []string{"11aa01229f15f0f0c52029d8cf8cd0aeaf2365fe4cebc4af26cd6d76b7919ef7", "11aa01229f15f0f0c52029d8cf8cd0aeaf2365fe4cebc4af26cd6d76b7919ef1"},
 		Platform: 1,
 		Message:  "Welcome",
@@ -745,19 +745,19 @@ func TestApnsHostFromRequest(t *testing.T) {
 	err = status.InitAppStatus(cfg)
 	assert.Nil(t, err)
 
-	req := PushNotification{
+	req := &PushNotification{
 		Production: true,
 	}
 	client := getApnsClient(cfg, req)
 	assert.Equal(t, apns2.HostProduction, client.Host)
 
-	req = PushNotification{
+	req = &PushNotification{
 		Development: true,
 	}
 	client = getApnsClient(cfg, req)
 	assert.Equal(t, apns2.HostDevelopment, client.Host)
 
-	req = PushNotification{}
+	req = &PushNotification{}
 	cfg.Ios.Production = true
 	client = getApnsClient(cfg, req)
 	assert.Equal(t, apns2.HostProduction, client.Host)

--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -35,7 +35,7 @@ func InitFCMClient(cfg *config.ConfYaml, key string) (*fcm.Client, error) {
 // GetAndroidNotification use for define Android notification.
 // HTTP Connection Server Reference for Android
 // https://firebase.google.com/docs/cloud-messaging/http-server-ref
-func GetAndroidNotification(req PushNotification) *fcm.Message {
+func GetAndroidNotification(req *PushNotification) *fcm.Message {
 	notification := &fcm.Message{
 		To:                    req.To,
 		Condition:             req.Condition,
@@ -105,7 +105,7 @@ func GetAndroidNotification(req PushNotification) *fcm.Message {
 }
 
 // PushToAndroid provide send notification to Android server.
-func PushToAndroid(req PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
+func PushToAndroid(req *PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
 	logx.LogAccess.Debug("Start push notification for Android")
 
 	var (
@@ -231,7 +231,7 @@ Retry:
 	return
 }
 
-func logPush(cfg *config.ConfYaml, status, token string, req PushNotification, err error) logx.LogPushEntry {
+func logPush(cfg *config.ConfYaml, status, token string, req *PushNotification, err error) logx.LogPushEntry {
 	return logx.LogPush(&logx.InputLog{
 		ID:        req.ID,
 		Status:    status,

--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -13,7 +13,7 @@ import (
 )
 
 // InitFCMClient use for initialize FCM Client.
-func InitFCMClient(cfg config.ConfYaml, key string) (*fcm.Client, error) {
+func InitFCMClient(cfg *config.ConfYaml, key string) (*fcm.Client, error) {
 	var err error
 
 	if key == "" && cfg.Android.APIKey == "" {
@@ -105,7 +105,7 @@ func GetAndroidNotification(req PushNotification) *fcm.Message {
 }
 
 // PushToAndroid provide send notification to Android server.
-func PushToAndroid(req PushNotification, cfg config.ConfYaml) (resp *ResponsePush, err error) {
+func PushToAndroid(req PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
 	logx.LogAccess.Debug("Start push notification for Android")
 
 	var (
@@ -231,7 +231,7 @@ Retry:
 	return
 }
 
-func logPush(cfg config.ConfYaml, status, token string, req PushNotification, err error) logx.LogPushEntry {
+func logPush(cfg *config.ConfYaml, status, token string, req PushNotification, err error) logx.LogPushEntry {
 	return logx.LogPush(&logx.InputLog{
 		ID:        req.ID,
 		Status:    status,

--- a/notify/notification_fcm_test.go
+++ b/notify/notification_fcm_test.go
@@ -39,7 +39,7 @@ func TestPushToAndroidWrongToken(t *testing.T) {
 	cfg.Android.Enabled = true
 	cfg.Android.APIKey = os.Getenv("ANDROID_API_KEY")
 
-	req := PushNotification{
+	req := &PushNotification{
 		Tokens:   []string{"aaaaaa", "bbbbb"},
 		Platform: core.PlatFormAndroid,
 		Message:  "Welcome",
@@ -59,7 +59,7 @@ func TestPushToAndroidRightTokenForJSONLog(t *testing.T) {
 
 	androidToken := os.Getenv("ANDROID_TEST_TOKEN")
 
-	req := PushNotification{
+	req := &PushNotification{
 		Tokens:   []string{androidToken},
 		Platform: core.PlatFormAndroid,
 		Message:  "Welcome",
@@ -76,7 +76,7 @@ func TestPushToAndroidRightTokenForStringLog(t *testing.T) {
 
 	androidToken := os.Getenv("ANDROID_TEST_TOKEN")
 
-	req := PushNotification{
+	req := &PushNotification{
 		Tokens:   []string{androidToken},
 		Platform: core.PlatFormAndroid,
 		Message:  "Welcome",
@@ -94,7 +94,7 @@ func TestOverwriteAndroidAPIKey(t *testing.T) {
 
 	androidToken := os.Getenv("ANDROID_TEST_TOKEN")
 
-	req := PushNotification{
+	req := &PushNotification{
 		Tokens:   []string{androidToken, "bbbbb"},
 		Platform: core.PlatFormAndroid,
 		Message:  "Welcome",
@@ -110,11 +110,10 @@ func TestOverwriteAndroidAPIKey(t *testing.T) {
 }
 
 func TestFCMMessage(t *testing.T) {
-	var req PushNotification
 	var err error
 
 	// the message must specify at least one registration ID
-	req = PushNotification{
+	req := &PushNotification{
 		Message: "Test",
 		Tokens:  []string{},
 	}
@@ -123,7 +122,7 @@ func TestFCMMessage(t *testing.T) {
 	assert.Error(t, err)
 
 	// the token must not be empty
-	req = PushNotification{
+	req = &PushNotification{
 		Message: "Test",
 		Tokens:  []string{""},
 	}
@@ -132,7 +131,7 @@ func TestFCMMessage(t *testing.T) {
 	assert.Error(t, err)
 
 	// ignore check token length if send topic message
-	req = PushNotification{
+	req = &PushNotification{
 		Message:  "Test",
 		Platform: core.PlatFormAndroid,
 		To:       "/topics/foo-bar",
@@ -142,7 +141,7 @@ func TestFCMMessage(t *testing.T) {
 	assert.NoError(t, err)
 
 	// "condition": "'dogs' in topics || 'cats' in topics",
-	req = PushNotification{
+	req = &PushNotification{
 		Message:   "Test",
 		Platform:  core.PlatFormAndroid,
 		Condition: "'dogs' in topics || 'cats' in topics",
@@ -152,7 +151,7 @@ func TestFCMMessage(t *testing.T) {
 	assert.NoError(t, err)
 
 	// the message may specify at most 1000 registration IDs
-	req = PushNotification{
+	req = &PushNotification{
 		Message:  "Test",
 		Platform: core.PlatFormAndroid,
 		Tokens:   make([]string, 1001),
@@ -164,7 +163,7 @@ func TestFCMMessage(t *testing.T) {
 	// the message's TimeToLive field must be an integer
 	// between 0 and 2419200 (4 weeks)
 	timeToLive := uint(2419201)
-	req = PushNotification{
+	req = &PushNotification{
 		Message:    "Test",
 		Platform:   core.PlatFormAndroid,
 		Tokens:     []string{"XXXXXXXXX"},
@@ -176,7 +175,7 @@ func TestFCMMessage(t *testing.T) {
 
 	// Pass
 	timeToLive = uint(86400)
-	req = PushNotification{
+	req = &PushNotification{
 		Message:    "Test",
 		Platform:   core.PlatFormAndroid,
 		Tokens:     []string{"XXXXXXXXX"},
@@ -194,7 +193,7 @@ func TestCheckAndroidMessage(t *testing.T) {
 	cfg.Android.APIKey = os.Getenv("ANDROID_API_KEY")
 
 	timeToLive := uint(2419201)
-	req := PushNotification{
+	req := &PushNotification{
 		Tokens:     []string{"aaaaaa", "bbbbb"},
 		Platform:   core.PlatFormAndroid,
 		Message:    "Welcome",
@@ -207,7 +206,7 @@ func TestCheckAndroidMessage(t *testing.T) {
 func TestAndroidNotificationStructure(t *testing.T) {
 	test := "test"
 	timeToLive := uint(100)
-	req := PushNotification{
+	req := &PushNotification{
 		Tokens:                []string{"a", "b"},
 		Message:               "Welcome",
 		To:                    test,
@@ -250,7 +249,7 @@ func TestAndroidNotificationStructure(t *testing.T) {
 	assert.Equal(t, 2, notification.Data["b"])
 
 	// test empty body
-	req = PushNotification{
+	req = &PushNotification{
 		Tokens: []string{"a", "b"},
 		To:     test,
 		Notification: &fcm.Notification{

--- a/notify/notification_hms.go
+++ b/notify/notification_hms.go
@@ -66,7 +66,7 @@ func InitHMSClient(cfg *config.ConfYaml, appSecret, appID string) (*client.HMSCl
 // GetHuaweiNotification use for define HMS notification.
 // HTTP Connection Server Reference for HMS
 // https://developer.huawei.com/consumer/en/doc/development/HMS-References/push-sendapi
-func GetHuaweiNotification(req PushNotification) (*model.MessageRequest, error) {
+func GetHuaweiNotification(req *PushNotification) (*model.MessageRequest, error) {
 	msgRequest := model.NewNotificationMsgRequest()
 
 	msgRequest.Message.Android = model.GetDefaultAndroid()
@@ -166,7 +166,7 @@ func GetHuaweiNotification(req PushNotification) (*model.MessageRequest, error) 
 }
 
 // PushToHuawei provide send notification to Android server.
-func PushToHuawei(req PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
+func PushToHuawei(req *PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
 	logx.LogAccess.Debug("Start push notification for Huawei")
 
 	var (

--- a/notify/notification_hms.go
+++ b/notify/notification_hms.go
@@ -36,7 +36,7 @@ func GetPushClient(conf *c.Config) (*client.HMSClient, error) {
 }
 
 // InitHMSClient use for initialize HMS Client.
-func InitHMSClient(cfg config.ConfYaml, appSecret, appID string) (*client.HMSClient, error) {
+func InitHMSClient(cfg *config.ConfYaml, appSecret, appID string) (*client.HMSClient, error) {
 	if appSecret == "" {
 		return nil, errors.New("Missing Huawei App Secret")
 	}
@@ -166,7 +166,7 @@ func GetHuaweiNotification(req PushNotification) (*model.MessageRequest, error) 
 }
 
 // PushToHuawei provide send notification to Android server.
-func PushToHuawei(req PushNotification, cfg config.ConfYaml) (resp *ResponsePush, err error) {
+func PushToHuawei(req PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
 	logx.LogAccess.Debug("Start push notification for Huawei")
 
 	var (

--- a/router/server.go
+++ b/router/server.go
@@ -63,7 +63,7 @@ func versionHandler(c *gin.Context) {
 	})
 }
 
-func pushHandler(cfg config.ConfYaml, q *queue.Queue) gin.HandlerFunc {
+func pushHandler(cfg *config.ConfYaml, q *queue.Queue) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var form notify.RequestPush
 		var msg string
@@ -113,7 +113,7 @@ func pushHandler(cfg config.ConfYaml, q *queue.Queue) gin.HandlerFunc {
 	}
 }
 
-func configHandler(cfg config.ConfYaml) gin.HandlerFunc {
+func configHandler(cfg *config.ConfYaml) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.YAML(http.StatusCreated, cfg)
 	}
@@ -157,7 +157,7 @@ func StatMiddleware() gin.HandlerFunc {
 	}
 }
 
-func autoTLSServer(cfg config.ConfYaml, q *queue.Queue) *http.Server {
+func autoTLSServer(cfg *config.ConfYaml, q *queue.Queue) *http.Server {
 	m := autocert.Manager{
 		Prompt:     autocert.AcceptTOS,
 		HostPolicy: autocert.HostWhitelist(cfg.Core.AutoTLS.Host),
@@ -171,7 +171,7 @@ func autoTLSServer(cfg config.ConfYaml, q *queue.Queue) *http.Server {
 	}
 }
 
-func routerEngine(cfg config.ConfYaml, q *queue.Queue) *gin.Engine {
+func routerEngine(cfg *config.ConfYaml, q *queue.Queue) *gin.Engine {
 	zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	if cfg.Core.Mode == "debug" {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
@@ -228,7 +228,7 @@ func routerEngine(cfg config.ConfYaml, q *queue.Queue) *gin.Engine {
 }
 
 // markFailedNotification adds failure logs for all tokens in push notification
-func markFailedNotification(cfg config.ConfYaml, notification *notify.PushNotification, reason string) []logx.LogPushEntry {
+func markFailedNotification(cfg *config.ConfYaml, notification *notify.PushNotification, reason string) []logx.LogPushEntry {
 	logx.LogError.Error(reason)
 	logs := make([]logx.LogPushEntry, 0)
 	for _, token := range notification.Tokens {
@@ -248,7 +248,7 @@ func markFailedNotification(cfg config.ConfYaml, notification *notify.PushNotifi
 }
 
 // HandleNotification add notification to queue list.
-func handleNotification(ctx context.Context, cfg config.ConfYaml, req notify.RequestPush, q *queue.Queue) (int, []logx.LogPushEntry) {
+func handleNotification(ctx context.Context, cfg *config.ConfYaml, req notify.RequestPush, q *queue.Queue) (int, []logx.LogPushEntry) {
 	var count int
 	wg := sync.WaitGroup{}
 	newNotification := []*notify.PushNotification{}
@@ -283,7 +283,7 @@ func handleNotification(ctx context.Context, cfg config.ConfYaml, req notify.Req
 		}
 
 		if core.IsLocalQueue(core.Queue(cfg.Queue.Engine)) && cfg.Core.Sync {
-			func(msg *notify.PushNotification, cfg config.ConfYaml) {
+			func(msg *notify.PushNotification, cfg *config.ConfYaml) {
 				q.QueueTask(func(ctx context.Context) error {
 					defer wg.Done()
 					resp, err := notify.SendNotification(msg, cfg)

--- a/router/server_lambda.go
+++ b/router/server_lambda.go
@@ -14,7 +14,7 @@ import (
 )
 
 // RunHTTPServer provide run http or https protocol.
-func RunHTTPServer(ctx context.Context, cfg config.ConfYaml, q *queue.Queue, s ...*http.Server) (err error) {
+func RunHTTPServer(ctx context.Context, cfg *config.ConfYaml, q *queue.Queue, s ...*http.Server) (err error) {
 	if !cfg.Core.Enabled {
 		logx.LogAccess.Debug("httpd server is disabled.")
 		return nil

--- a/router/server_normal.go
+++ b/router/server_normal.go
@@ -18,7 +18,7 @@ import (
 )
 
 // RunHTTPServer provide run http or https protocol.
-func RunHTTPServer(ctx context.Context, cfg config.ConfYaml, q *queue.Queue, s ...*http.Server) (err error) {
+func RunHTTPServer(ctx context.Context, cfg *config.ConfYaml, q *queue.Queue, s ...*http.Server) (err error) {
 	var server *http.Server
 
 	if !cfg.Core.Enabled {
@@ -79,7 +79,7 @@ func RunHTTPServer(ctx context.Context, cfg config.ConfYaml, q *queue.Queue, s .
 	return startServer(ctx, server, cfg)
 }
 
-func listenAndServe(ctx context.Context, s *http.Server, cfg config.ConfYaml) error {
+func listenAndServe(ctx context.Context, s *http.Server, cfg *config.ConfYaml) error {
 	var g errgroup.Group
 	g.Go(func() error {
 		select {
@@ -99,7 +99,7 @@ func listenAndServe(ctx context.Context, s *http.Server, cfg config.ConfYaml) er
 	return g.Wait()
 }
 
-func listenAndServeTLS(ctx context.Context, s *http.Server, cfg config.ConfYaml) error {
+func listenAndServeTLS(ctx context.Context, s *http.Server, cfg *config.ConfYaml) error {
 	var g errgroup.Group
 	g.Go(func() error {
 		select {
@@ -119,7 +119,7 @@ func listenAndServeTLS(ctx context.Context, s *http.Server, cfg config.ConfYaml)
 	return g.Wait()
 }
 
-func startServer(ctx context.Context, s *http.Server, cfg config.ConfYaml) error {
+func startServer(ctx context.Context, s *http.Server, cfg *config.ConfYaml) error {
 	if s.TLSConfig == nil {
 		return listenAndServe(ctx, s, cfg)
 	}

--- a/router/server_test.go
+++ b/router/server_test.go
@@ -62,7 +62,7 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func initTest() config.ConfYaml {
+func initTest() *config.ConfYaml {
 	cfg, _ := config.LoadConf()
 	cfg.Core.Mode = "test"
 	return cfg

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -20,14 +20,14 @@ import (
 
 // Server is used to implement gorush grpc server.
 type Server struct {
-	cfg config.ConfYaml
+	cfg *config.ConfYaml
 	mu  sync.Mutex
 	// statusMap stores the serving status of the services this Server monitors.
 	statusMap map[string]proto.HealthCheckResponse_ServingStatus
 }
 
 // NewServer returns a new Server.
-func NewServer(cfg config.ConfYaml) *Server {
+func NewServer(cfg *config.ConfYaml) *Server {
 	return &Server{
 		cfg:       cfg,
 		statusMap: make(map[string]proto.HealthCheckResponse_ServingStatus),
@@ -110,7 +110,7 @@ func (s *Server) Send(ctx context.Context, in *proto.NotificationRequest) (*prot
 }
 
 // RunGRPCServer run gorush grpc server
-func RunGRPCServer(ctx context.Context, cfg config.ConfYaml) error {
+func RunGRPCServer(ctx context.Context, cfg *config.ConfYaml) error {
 	if !cfg.GRPC.Enabled {
 		logx.LogAccess.Info("gRPC server is disabled.")
 		return nil

--- a/rpc/server_test.go
+++ b/rpc/server_test.go
@@ -12,7 +12,7 @@ import (
 
 const gRPCAddr = "localhost:9000"
 
-func initTest() config.ConfYaml {
+func initTest() *config.ConfYaml {
 	cfg, _ := config.LoadConf()
 	cfg.Core.Mode = "test"
 	return cfg

--- a/status/status.go
+++ b/status/status.go
@@ -52,7 +52,7 @@ type HuaweiStatus struct {
 }
 
 // InitAppStatus for initialize app status
-func InitAppStatus(conf config.ConfYaml) error {
+func InitAppStatus(conf *config.ConfYaml) error {
 	logx.LogAccess.Info("Init App Status Engine as ", conf.Stat.Engine)
 	switch conf.Stat.Engine {
 	case "memory":

--- a/storage/badger/badger.go
+++ b/storage/badger/badger.go
@@ -13,7 +13,7 @@ import (
 )
 
 // New func implements the storage interface for gorush (https://github.com/appleboy/gorush)
-func New(config config.ConfYaml) *Storage {
+func New(config *config.ConfYaml) *Storage {
 	return &Storage{
 		config: config,
 	}
@@ -21,7 +21,7 @@ func New(config config.ConfYaml) *Storage {
 
 // Storage is interface structure
 type Storage struct {
-	config config.ConfYaml
+	config *config.ConfYaml
 	opts   badger.Options
 	name   string
 	db     *badger.DB

--- a/storage/boltdb/boltdb.go
+++ b/storage/boltdb/boltdb.go
@@ -10,7 +10,7 @@ import (
 )
 
 // New func implements the storage interface for gorush (https://github.com/appleboy/gorush)
-func New(config config.ConfYaml) *Storage {
+func New(config *config.ConfYaml) *Storage {
 	return &Storage{
 		config: config,
 	}
@@ -18,7 +18,7 @@ func New(config config.ConfYaml) *Storage {
 
 // Storage is interface structure
 type Storage struct {
-	config config.ConfYaml
+	config *config.ConfYaml
 	db     *storm.DB
 }
 

--- a/storage/buntdb/buntdb.go
+++ b/storage/buntdb/buntdb.go
@@ -12,7 +12,7 @@ import (
 )
 
 // New func implements the storage interface for gorush (https://github.com/appleboy/gorush)
-func New(config config.ConfYaml) *Storage {
+func New(config *config.ConfYaml) *Storage {
 	return &Storage{
 		config: config,
 	}
@@ -20,7 +20,7 @@ func New(config config.ConfYaml) *Storage {
 
 // Storage is interface structure
 type Storage struct {
-	config config.ConfYaml
+	config *config.ConfYaml
 	db     *buntdb.DB
 }
 

--- a/storage/leveldb/leveldb.go
+++ b/storage/leveldb/leveldb.go
@@ -21,7 +21,7 @@ func (s *Storage) getLevelDB(key string, count *int64) {
 }
 
 // New func implements the storage interface for gorush (https://github.com/appleboy/gorush)
-func New(config config.ConfYaml) *Storage {
+func New(config *config.ConfYaml) *Storage {
 	return &Storage{
 		config: config,
 	}
@@ -29,7 +29,7 @@ func New(config config.ConfYaml) *Storage {
 
 // Storage is interface structure
 type Storage struct {
-	config config.ConfYaml
+	config *config.ConfYaml
 	db     *leveldb.DB
 }
 

--- a/storage/redis/redis.go
+++ b/storage/redis/redis.go
@@ -10,7 +10,7 @@ import (
 )
 
 // New func implements the storage interface for gorush (https://github.com/appleboy/gorush)
-func New(config config.ConfYaml) *Storage {
+func New(config *config.ConfYaml) *Storage {
 	return &Storage{
 		config: config,
 	}
@@ -23,7 +23,7 @@ func (s *Storage) getInt64(key string, count *int64) {
 
 // Storage is interface structure
 type Storage struct {
-	config config.ConfYaml
+	config *config.ConfYaml
 	client *redis.Client
 }
 


### PR DESCRIPTION
fix #619 

> When a param big in size (more than 80 bytes) is passed to another function, it is better to pass a pointer to the value around, rather than the value itself.

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>