### PR TITLE
chore: replace appleboy/queue with new repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,13 +7,15 @@ require (
 	github.com/appleboy/gin-status-api v1.1.0
 	github.com/appleboy/go-fcm v0.1.5
 	github.com/appleboy/gofight/v2 v2.1.2
-	github.com/appleboy/queue v0.0.5
 	github.com/asdine/storm/v3 v3.2.1
 	github.com/buger/jsonparser v1.1.1
 	github.com/dgraph-io/badger/v3 v3.2103.1
 	github.com/gin-contrib/logger v0.2.0
 	github.com/gin-gonic/gin v1.7.2
 	github.com/go-redis/redis/v7 v7.4.0
+	github.com/golang-queue/nats v0.0.1
+	github.com/golang-queue/nsq v0.0.1
+	github.com/golang-queue/queue v0.0.6
 	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect
 	github.com/golang/protobuf v1.5.2
 	github.com/google/flatbuffers v2.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/appleboy/go-fcm v0.1.5 h1:fKbcZf/7vwGsvDkcop8a+kCHnK+tt4wXX0X7uEzwI6E
 github.com/appleboy/go-fcm v0.1.5/go.mod h1:MSxZ4LqGRsnywOjnlXJXMqbjZrG4vf+0oHitfC9HRH0=
 github.com/appleboy/gofight/v2 v2.1.2 h1:VOy3jow4vIK8BRQJoC/I9muxyYlJ2yb9ht2hZoS3rf4=
 github.com/appleboy/gofight/v2 v2.1.2/go.mod h1:frW+U1QZEdDgixycTj4CygQ48yLTUhplt43+Wczp3rw=
-github.com/appleboy/queue v0.0.5 h1:4wrS83ktdxg3U0YGx1EC9mU8vXD4BCAswAliqCEaxHw=
-github.com/appleboy/queue v0.0.5/go.mod h1:cEQW2y7dduAUqUGnGJEK9oM5bZLlc0+3HI9bTUL0+Ek=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -156,6 +154,12 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-queue/nats v0.0.1 h1:8P5YOHP6BdqJfIa47VfQ5+1sInIsWxnema/UcdpM9NE=
+github.com/golang-queue/nats v0.0.1/go.mod h1:B+5LDTDILJiH9eplW7ETKKMlMA4vRDAvOkQzFjmVQ/o=
+github.com/golang-queue/nsq v0.0.1 h1:7IgLshRYC5AsX3QnMyWDKfrR/WSTanAPqQX3XxV0O7I=
+github.com/golang-queue/nsq v0.0.1/go.mod h1:hvxpT5CcllnL2iesg/m7Ih1fBjO/METlbXmwS8/tHpk=
+github.com/golang-queue/queue v0.0.6 h1:TLd0lSM7uNgXXj7SXSMfyaZUwRgbOu9tq6UfZXXELnA=
+github.com/golang-queue/queue v0.0.6/go.mod h1:IeIGBO1largDrFEaxDgIckoAFIUTn0eolTQris8bm08=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v0.0.0-20210429001901-424d2337a529 h1:2voWjNECnrZRbfwXxHB1/j8wa6xdKn85B5NzgVL/pTU=
 github.com/golang/glog v0.0.0-20210429001901-424d2337a529/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/main.go
+++ b/main.go
@@ -22,10 +22,10 @@ import (
 	"github.com/appleboy/gorush/rpc"
 	"github.com/appleboy/gorush/status"
 
-	"github.com/appleboy/queue"
-	"github.com/appleboy/queue/nats"
-	"github.com/appleboy/queue/nsq"
-	"github.com/appleboy/queue/simple"
+	"github.com/golang-queue/nats"
+	"github.com/golang-queue/nsq"
+	"github.com/golang-queue/queue"
+	"github.com/golang-queue/queue/simple"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -13,7 +13,7 @@ import (
 	"github.com/appleboy/gorush/logx"
 
 	"github.com/appleboy/go-fcm"
-	"github.com/appleboy/queue"
+	"github.com/golang-queue/queue"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/msalihkarakasli/go-hms-push/push/model"
 )

--- a/router/server.go
+++ b/router/server.go
@@ -17,10 +17,10 @@ import (
 	"github.com/appleboy/gorush/status"
 
 	api "github.com/appleboy/gin-status-api"
-	"github.com/appleboy/queue"
 	"github.com/gin-contrib/logger"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
+	"github.com/golang-queue/queue"
 	"github.com/mattn/go-isatty"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/router/server_lambda.go
+++ b/router/server_lambda.go
@@ -10,7 +10,7 @@ import (
 	"github.com/appleboy/gorush/logx"
 
 	"github.com/apex/gateway"
-	"github.com/appleboy/queue"
+	"github.com/golang-queue/queue"
 )
 
 // RunHTTPServer provide run http or https protocol.

--- a/router/server_normal.go
+++ b/router/server_normal.go
@@ -13,7 +13,7 @@ import (
 	"github.com/appleboy/gorush/config"
 	"github.com/appleboy/gorush/logx"
 
-	"github.com/appleboy/queue"
+	"github.com/golang-queue/queue"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/router/server_test.go
+++ b/router/server_test.go
@@ -18,10 +18,10 @@ import (
 	"github.com/appleboy/gorush/status"
 
 	"github.com/appleboy/gofight/v2"
-	"github.com/appleboy/queue"
-	"github.com/appleboy/queue/simple"
 	"github.com/buger/jsonparser"
 	"github.com/gin-gonic/gin"
+	"github.com/golang-queue/queue"
+	"github.com/golang-queue/queue/simple"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
move appleboy/queue to [golang-queue/queue](https://github.com/golang-queue/queue)

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>