### PR TITLE
add request logs for iOS:APNs and Android:FCM

### DIFF
--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -288,7 +288,7 @@ func iosAlertDictionary(payload *payload.Payload, req *PushNotification) *payloa
 // GetIOSNotification use for define iOS notification.
 // The iOS Notification Payload (Payload Key Reference)
 // Ref: https://apple.co/2VtH6Iu
-func GetIOSNotification(req *PushNotification) (*apns2.Notification, error) {
+func GetIOSNotification(req *PushNotification) *apns2.Notification {
 	notification := &apns2.Notification{
 		ApnsID:     req.ApnsID,
 		Topic:      req.Topic,
@@ -370,13 +370,12 @@ func GetIOSNotification(req *PushNotification) (*apns2.Notification, error) {
 
 	jsonMarshall, err := json.Marshal(notification)
 	if err != nil {
-		logx.LogError.Error("Failed to marshal the default message! Error is " + err.Error())
-		return nil, err
+		logx.LogError.Warnf("Failed to marshal the default message! Error: %v", err)
+	} else {
+		logx.LogAccess.Debugf("Default message going to APNs is %s", string(jsonMarshall))
 	}
 
-	logx.LogAccess.Debugf("Default message going to APNs is %s", string(jsonMarshall))
-
-	return notification, nil
+	return notification
 }
 
 func getApnsClient(cfg *config.ConfYaml, req *PushNotification) (client *apns2.Client) {
@@ -414,7 +413,7 @@ func PushToIOS(req *PushNotification, cfg *config.ConfYaml) (resp *ResponsePush,
 Retry:
 	var newTokens []string
 
-	notification, _ := GetIOSNotification(req)
+	notification := GetIOSNotification(req)
 	client := getApnsClient(cfg, req)
 
 	var wg sync.WaitGroup

--- a/notify/notification_apns_test.go
+++ b/notify/notification_apns_test.go
@@ -83,7 +83,7 @@ func TestIOSNotificationStructure(t *testing.T) {
 		URLArgs:  []string{"a", "b"},
 	}
 
-	notification, _ := GetIOSNotification(req)
+	notification := GetIOSNotification(req)
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))
@@ -139,7 +139,7 @@ func TestIOSSoundAndVolume(t *testing.T) {
 		},
 	}
 
-	notification, _ := GetIOSNotification(req)
+	notification := GetIOSNotification(req)
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))
@@ -163,7 +163,7 @@ func TestIOSSoundAndVolume(t *testing.T) {
 
 	req.SoundName = "foobar"
 	req.SoundVolume = 5.5
-	notification, _ = GetIOSNotification(req)
+	notification = GetIOSNotification(req)
 	dump, _ = json.Marshal(notification.Payload)
 	data = []byte(string(dump))
 
@@ -190,7 +190,7 @@ func TestIOSSoundAndVolume(t *testing.T) {
 		},
 	}
 
-	notification, _ = GetIOSNotification(req)
+	notification = GetIOSNotification(req)
 	dump, _ = json.Marshal(notification.Payload)
 	data = []byte(string(dump))
 
@@ -213,7 +213,7 @@ func TestIOSSoundAndVolume(t *testing.T) {
 		Sound:    "default",
 	}
 
-	notification, _ = GetIOSNotification(req)
+	notification = GetIOSNotification(req)
 	dump, _ = json.Marshal(notification.Payload)
 	data = []byte(string(dump))
 
@@ -241,7 +241,7 @@ func TestIOSSummaryArg(t *testing.T) {
 		},
 	}
 
-	notification, _ := GetIOSNotification(req)
+	notification := GetIOSNotification(req)
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))
@@ -275,7 +275,7 @@ func TestSendZeroValueForBadgeKey(t *testing.T) {
 		ThreadID:         test,
 	}
 
-	notification, _ := GetIOSNotification(req)
+	notification := GetIOSNotification(req)
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))
@@ -310,7 +310,7 @@ func TestSendZeroValueForBadgeKey(t *testing.T) {
 	expectBadge := 10
 	req.Badge = &expectBadge
 
-	notification, _ = GetIOSNotification(req)
+	notification = GetIOSNotification(req)
 
 	dump, _ = json.Marshal(notification.Payload)
 	data = []byte(string(dump))
@@ -345,7 +345,7 @@ func TestCheckSilentNotification(t *testing.T) {
 		ContentAvailable: true,
 	}
 
-	notification, _ := GetIOSNotification(req)
+	notification := GetIOSNotification(req)
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))
@@ -395,7 +395,7 @@ func TestAlertStringExample2ForIos(t *testing.T) {
 		},
 	}
 
-	notification, _ := GetIOSNotification(req)
+	notification := GetIOSNotification(req)
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))
@@ -437,7 +437,7 @@ func TestAlertStringExample3ForIos(t *testing.T) {
 		Sound:            sound,
 	}
 
-	notification, _ := GetIOSNotification(req)
+	notification := GetIOSNotification(req)
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))
@@ -467,7 +467,7 @@ func TestMessageAndTitle(t *testing.T) {
 		ContentAvailable: true,
 	}
 
-	notification, _ := GetIOSNotification(req)
+	notification := GetIOSNotification(req)
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))
@@ -491,7 +491,7 @@ func TestMessageAndTitle(t *testing.T) {
 	messageOverride := "Welcome notification Server overridden"
 	req.Alert.Body = messageOverride
 
-	notification, _ = GetIOSNotification(req)
+	notification = GetIOSNotification(req)
 
 	dump, _ = json.Marshal(notification.Payload)
 	data = []byte(string(dump))
@@ -528,7 +528,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 		},
 	}
 
-	notification, _ := GetIOSNotification(req)
+	notification := GetIOSNotification(req)
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))

--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -35,7 +35,7 @@ func InitFCMClient(cfg *config.ConfYaml, key string) (*fcm.Client, error) {
 // GetAndroidNotification use for define Android notification.
 // HTTP Connection Server Reference for Android
 // https://firebase.google.com/docs/cloud-messaging/http-server-ref
-func GetAndroidNotification(req *PushNotification) (*fcm.Message, error) {
+func GetAndroidNotification(req *PushNotification) *fcm.Message {
 	notification := &fcm.Message{
 		To:                    req.To,
 		Condition:             req.Condition,
@@ -103,13 +103,12 @@ func GetAndroidNotification(req *PushNotification) (*fcm.Message, error) {
 
 	jsonMarshall, err := json.Marshal(notification)
 	if err != nil {
-		logx.LogError.Error("Failed to marshal the default message! Error is " + err.Error())
-		return nil, err
+		logx.LogError.Warnf("Failed to marshal the default message! Error: %v", err)
+	} else {
+		logx.LogAccess.Debugf("Default message going to FCM server is %s", string(jsonMarshall))
 	}
 
-	logx.LogAccess.Debugf("Default message going to FCM server is %s", string(jsonMarshall))
-
-	return notification, nil
+	return notification
 }
 
 // PushToAndroid provide send notification to Android server.
@@ -136,7 +135,7 @@ func PushToAndroid(req *PushNotification, cfg *config.ConfYaml) (resp *ResponseP
 	resp = &ResponsePush{}
 
 Retry:
-	notification, _ := GetAndroidNotification(req)
+	notification := GetAndroidNotification(req)
 
 	if req.APIKey != "" {
 		client, err = InitFCMClient(cfg, req.APIKey)

--- a/notify/notification_fcm_test.go
+++ b/notify/notification_fcm_test.go
@@ -239,7 +239,7 @@ func TestAndroidNotificationStructure(t *testing.T) {
 		},
 	}
 
-	notification, _ := GetAndroidNotification(req)
+	notification := GetAndroidNotification(req)
 
 	assert.Equal(t, test, notification.To)
 	assert.Equal(t, "high", notification.Priority)
@@ -265,7 +265,7 @@ func TestAndroidNotificationStructure(t *testing.T) {
 			Body: "",
 		},
 	}
-	notification, _ = GetAndroidNotification(req)
+	notification = GetAndroidNotification(req)
 
 	assert.Equal(t, test, notification.To)
 	assert.Equal(t, "", notification.Notification.Body)

--- a/notify/notification_hms.go
+++ b/notify/notification_hms.go
@@ -66,7 +66,7 @@ func InitHMSClient(cfg *config.ConfYaml, appSecret, appID string) (*client.HMSCl
 // GetHuaweiNotification use for define HMS notification.
 // HTTP Connection Server Reference for HMS
 // https://developer.huawei.com/consumer/en/doc/development/HMS-References/push-sendapi
-func GetHuaweiNotification(req *PushNotification) (*model.MessageRequest, error) {
+func GetHuaweiNotification(req *PushNotification) *model.MessageRequest {
 	msgRequest := model.NewNotificationMsgRequest()
 
 	msgRequest.Message.Android = model.GetDefaultAndroid()
@@ -155,14 +155,14 @@ func GetHuaweiNotification(req *PushNotification) (*model.MessageRequest, error)
 		}
 	}
 
-	b, err := json.Marshal(msgRequest)
+	jsonMarshall, err := json.Marshal(msgRequest)
 	if err != nil {
-		logx.LogError.Error("Failed to marshal the default message! Error is " + err.Error())
-		return nil, err
+		logx.LogError.Warnf("Failed to marshal the default message! Error: %v", err)
+	} else {
+		logx.LogAccess.Debugf("Default message going to Huawei Push server is %s", string(jsonMarshall))
 	}
 
-	logx.LogAccess.Debugf("Default message going to Huawei Push Server is %s", string(b))
-	return msgRequest, nil
+	return msgRequest
 }
 
 // PushToHuawei provide send notification to Android server.
@@ -199,7 +199,7 @@ func PushToHuawei(req *PushNotification, cfg *config.ConfYaml) (resp *ResponsePu
 Retry:
 	isError := false
 
-	notification, _ := GetHuaweiNotification(req)
+	notification := GetHuaweiNotification(req)
 
 	res, err := client.SendMessage(context.Background(), notification)
 	if err != nil {


### PR DESCRIPTION
APNs and FCM Api request logs added to see which requests are going to APNs And FCM servers

Example:


- [x] request going gorush:

```
{
  "notifications": [
    {
      "platform": 1,
      "priority": "high",
      "tokens": [
        "**********4wAABp_BOYhKWWMLfSF9GV52UO_rYvBoKbQuuuI6HWSfLdG7_t-ZhA2_Zg47BpQbzBegmHUxovPTp3rU0xajPAfnz9IkOb**********"
      ],
      "content_available": true,
      "category": "CONFIRM",
      "sound": {
        "critical": 1,
        "name": "default",
        "volume": 1
      },
      "alert": {
        "body": "iOS UAT başarılı bildirim geldi"
      },
      "data": {
        "customerNo": 12345,
        "languageCode": "tr",
        "specificCharText": "denemee"
      }
    }
  ]
}
```


- [ ] request going APNS: (**We need this**)

```
{
  "aps": {
    "alert": {
      "body": "iOS UAT başarılı bildirim geldi"
    },
    "category": "CONFIRM",
    "content-available": 1,
    "sound": {
      "critical": 1,
      "name": "default",
      "volume": 1
    }
  },
  "customerNo": 12345,
  "languageCode": "tr",
  "specificCharText": "denemee"
}
```