### PR TITLE
Set default value for ios.max_concurrent_pushes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -368,6 +368,10 @@ func LoadConf(confPath ...string) (*ConfYaml, error) {
 	conf.Ios.KeyID = viper.GetString("ios.key_id")
 	conf.Ios.TeamID = viper.GetString("ios.team_id")
 
+	if conf.Ios.MaxConcurrentPushes == 0 {
+		conf.Ios.MaxConcurrentPushes = 100
+	}
+
 	// log
 	conf.Log.Format = viper.GetString("log.format")
 	conf.Log.AccessLog = viper.GetString("log.access_log")


### PR DESCRIPTION
I upgraded gorush running on my server and the old config did not have `ios.max_concurrent_pushes`. The default value was then 0 and the iOS queue was blocked forever.

This PR simply set a sane default value for `MaxConcurrentPushes` to not be 0.

Fixes #536 