### PR TITLE
chore(conf): add default value for max_concurrent_pushes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -277,9 +277,16 @@ type SectionGRPC struct {
 	Port    string `yaml:"port"`
 }
 
+func setDefault() {
+	viper.SetDefault("ios.max_concurrent_pushes", uint(100))
+}
+
 // LoadConf load config from file and read in environment variables that match
 func LoadConf(confPath ...string) (*ConfYaml, error) {
 	conf := &ConfYaml{}
+
+	// load default values
+	setDefault()
 
 	viper.SetConfigType("yaml")
 	viper.AutomaticEnv()         // read in environment variables that match

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,6 +17,15 @@ func TestMissingFile(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestEmptyConfig(t *testing.T) {
+	conf, err := LoadConf("testdata/empty.yml")
+	if err != nil {
+		panic("failed to load config.yml from file")
+	}
+
+	assert.Equal(t, uint(100), conf.Ios.MaxConcurrentPushes)
+}
+
 type ConfigTestSuite struct {
 	suite.Suite
 	ConfGorushDefault *ConfYaml


### PR DESCRIPTION
Set default value for ios.max_concurrent_pushes

See the comment https://github.com/appleboy/gorush/pull/643

Nothing is written in the Readme that this parameter is new from this version

fix #643 and #536

cc @slimus @raoulh 

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>