### PR TITLE
#668: KeyPath can't contain a dot when deploying with Terraform

### DIFF
--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -61,6 +61,11 @@ func InitAPNSClient(cfg *config.ConfYaml) error {
 
 		if cfg.Ios.KeyPath != "" {
 			ext = filepath.Ext(cfg.Ios.KeyPath)
+			if ext == "" {
+				// If the file has no extension, use KeyType
+				// This makes it possible to deploy GoRush with Terraform where the name of volume_mounts can only contain alphanumeric characters, hyphens and underscores but no dots
+				ext = "." + cfg.Ios.KeyType
+			}
 
 			switch ext {
 			case ".p12":


### PR DESCRIPTION
GoRush uses the KeyPath file extension in order to determine how to create the certificate (.p12, .pem, .p8). However if you use Terraform to deploy GoRush, the name of volume_mounts can only contain alphanumeric characters, hyphens and underscores but no dots. This seems to make it impossible to deploy GoRush with Terraform and mount a KeyPath file from the GCP Secret Manager.

This change implements the suggestion written in the #668 ticket: if KeyPath has no extension, we can fallback to KeyType to determine the type.