### PR TITLE
fix: Serialise nested protobuf structs correctly

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"strings"
 	"sync"
@@ -97,10 +96,7 @@ func (s *Server) Send(ctx context.Context, in *proto.NotificationRequest) (*prot
 	}
 
 	if in.Data != nil {
-		notification.Data = map[string]interface{}{}
-		for k, v := range in.Data.AsMap() {
-			notification.Data[k] = fmt.Sprintf("%v", v)
-		}
+		notification.Data = in.Data.AsMap()
 	}
 
 	go func() {


### PR DESCRIPTION
This PR addresses https://github.com/appleboy/gorush/issues/671

When a notification request is received via the gRPC server, the `Data` field in the request is parsed from a `*structpb.Struct` into a `map[string]interface{}`. This map will eventually be serialised with `json.Marshal` ([here](https://github.com/appleboy/gorush/blob/master/notify/notification.go#L239) or [here](https://github.com/appleboy/go-fcm/blob/master/client.go#L73)).

Using `fmt.Sprintf("%v", v)` to parse each value in the struct caused nested structs to be serialised as strings, e.g.:

    {"popup":"map[body:how are you? title:hey]","source":"poc.pushnotif"}

Using `structpb.AsMap` directly yields the correct serialisation:

    {"popup":{"body":"how are you?","title":"hey"},"source":"poc.pushnotif"}

You can see an example [in this code snippet](https://go.dev/play/p/dsCQbrJHM74).