### PR TITLE
chore(message): Add option to redact contents of messages in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ log:
   error_log: "stderr" # stderr: output to console, or define log path like "log/error_log"
   error_level: "error"
   hide_token: true
+  hide_messages: false
 
 stat:
   engine: "memory" # support memory, redis, boltdb, buntdb or leveldb

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-//nolint
+// nolint
 var defaultConf = []byte(`
 core:
   enabled: true # enable httpd server
@@ -98,6 +98,7 @@ log:
   error_log: "stderr" # stderr: output to console, or define log path like "log/error_log"
   error_level: "error"
   hide_token: true
+  hide_messages: false
 
 stat:
   engine: "memory" # support memory, redis, boltdb, buntdb or leveldb
@@ -202,12 +203,13 @@ type SectionIos struct {
 
 // SectionLog is sub section of config.
 type SectionLog struct {
-	Format      string `yaml:"format"`
-	AccessLog   string `yaml:"access_log"`
-	AccessLevel string `yaml:"access_level"`
-	ErrorLog    string `yaml:"error_log"`
-	ErrorLevel  string `yaml:"error_level"`
-	HideToken   bool   `yaml:"hide_token"`
+	Format       string `yaml:"format"`
+	AccessLog    string `yaml:"access_log"`
+	AccessLevel  string `yaml:"access_level"`
+	ErrorLog     string `yaml:"error_log"`
+	ErrorLevel   string `yaml:"error_level"`
+	HideToken    bool   `yaml:"hide_token"`
+	HideMessages bool   `yaml:"hide_messages"`
 }
 
 // SectionStat is sub section of config.
@@ -397,6 +399,7 @@ func LoadConf(confPath ...string) (*ConfYaml, error) {
 	conf.Log.ErrorLog = viper.GetString("log.error_log")
 	conf.Log.ErrorLevel = viper.GetString("log.error_level")
 	conf.Log.HideToken = viper.GetBool("log.hide_token")
+	conf.Log.HideMessages = viper.GetBool("log.hide_messages")
 
 	// Queue Engine
 	conf.Queue.Engine = viper.GetString("queue.engine")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -119,6 +119,7 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), "stderr", suite.ConfGorushDefault.Log.ErrorLog)
 	assert.Equal(suite.T(), "error", suite.ConfGorushDefault.Log.ErrorLevel)
 	assert.Equal(suite.T(), true, suite.ConfGorushDefault.Log.HideToken)
+	assert.Equal(suite.T(), false, suite.ConfGorushDefault.Log.HideMessages)
 
 	assert.Equal(suite.T(), "memory", suite.ConfGorushDefault.Stat.Engine)
 	assert.Equal(suite.T(), false, suite.ConfGorushDefault.Stat.Redis.Cluster)

--- a/config/testdata/config.yml
+++ b/config/testdata/config.yml
@@ -84,6 +84,7 @@ log:
   error_log: "stderr" # stderr: output to console, or define log path like "log/error_log"
   error_level: "error"
   hide_token: true
+  hide_messages: false
 
 stat:
   engine: "memory" # support memory, redis, boltdb, buntdb or leveldb

--- a/logx/log.go
+++ b/logx/log.go
@@ -33,7 +33,7 @@ type LogPushEntry struct {
 
 var isTerm bool
 
-//nolint
+// nolint
 func init() {
 	isTerm = isatty.IsTerminal(os.Stdout.Fd())
 }
@@ -175,26 +175,32 @@ func GetLogPushEntry(input *InputLog) LogPushEntry {
 		token = hideToken(input.Token, 10)
 	}
 
+	message := input.Message
+	if input.HideMessage {
+		message = "(message redacted)"
+	}
+
 	return LogPushEntry{
 		ID:       input.ID,
 		Type:     input.Status,
 		Platform: plat,
 		Token:    token,
-		Message:  input.Message,
+		Message:  message,
 		Error:    errMsg,
 	}
 }
 
 // InputLog log request
 type InputLog struct {
-	ID        string
-	Status    string
-	Token     string
-	Message   string
-	Platform  int
-	Error     error
-	HideToken bool
-	Format    string
+	ID          string
+	Status      string
+	Token       string
+	Message     string
+	Platform    int
+	Error       error
+	HideToken   bool
+	HideMessage bool
+	Format      string
 }
 
 // LogPush record user push request and server response.

--- a/logx/log_test.go
+++ b/logx/log_test.go
@@ -154,6 +154,10 @@ func TestLogPushEntry(t *testing.T) {
 	in.Token = "1234567890"
 	in.HideToken = true
 	assert.Equal(t, "**********", GetLogPushEntry(&in).Token)
+
+	in.Message = "hellothisisamessage"
+	in.HideMessage = true
+	assert.Equal(t, "(message redacted)", GetLogPushEntry(&in).Message)
 }
 
 func TestLogPush(t *testing.T) {

--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -234,13 +234,14 @@ Retry:
 
 func logPush(cfg *config.ConfYaml, status, token string, req *PushNotification, err error) logx.LogPushEntry {
 	return logx.LogPush(&logx.InputLog{
-		ID:        req.ID,
-		Status:    status,
-		Token:     token,
-		Message:   req.Message,
-		Platform:  req.Platform,
-		Error:     err,
-		HideToken: cfg.Log.HideToken,
-		Format:    cfg.Log.Format,
+		ID:          req.ID,
+		Status:      status,
+		Token:       token,
+		Message:     req.Message,
+		Platform:    req.Platform,
+		Error:       err,
+		HideToken:   cfg.Log.HideToken,
+		HideMessage: cfg.Log.HideMessages,
+		Format:      cfg.Log.Format,
 	})
 }


### PR DESCRIPTION
Hello, we're using gorush in a situation where we need to redact the contents of messages in logs. We didn't see a way to make this happen so we forked and implemented this, and thought a PR may be useful.

Adds:

* `log.hide_messages` setting to hide the contents of messages in logs