### PR TITLE
chore(feedbak): refactor feedback dispatch and configuration handling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-//nolint
 var defaultConf = []byte(`
 core:
   enabled: true # enable httpd server
@@ -20,9 +19,13 @@ core:
   worker_num: 0 # default worker number is runtime.NumCPU()
   queue_num: 0 # default queue number is 8192
   max_notification: 100
-  sync: false # set true if you need get error message from fail push notification in API response. It only works when the queue engine is local.
-  feedback_hook_url: "" # set webhook url if you need get error message asynchronously from fail push notification in API response.
+  # set true if you need get error message from fail push notification in API response.
+  # It only works when the queue engine is local.
+  sync: false
+  # set webhook url if you need get error message asynchronously from fail push notification in API response.
+  feedback_hook_url: ""
   feedback_timeout: 10 # default is 10 second
+  feedback_header:
   mode: "release"
   ssl: false
   cert_path: "cert.pem"
@@ -148,10 +151,12 @@ type SectionCore struct {
 	CertBase64      string         `yaml:"cert_base64"`
 	KeyBase64       string         `yaml:"key_base64"`
 	HTTPProxy       string         `yaml:"http_proxy"`
-	FeedbackURL     string         `yaml:"feedback_hook_url"`
-	FeedbackTimeout int64          `yaml:"feedback_timeout"`
 	PID             SectionPID     `yaml:"pid"`
 	AutoTLS         SectionAutoTLS `yaml:"auto_tls"`
+
+	FeedbackURL     string   `yaml:"feedback_hook_url"`
+	FeedbackTimeout int64    `yaml:"feedback_timeout"`
+	FeedbackHeader  []string `yaml:"feedback_header"`
 }
 
 // SectionAutoTLS support Let's Encrypt setting.
@@ -346,6 +351,7 @@ func LoadConf(confPath ...string) (*ConfYaml, error) {
 	conf.Core.Sync = viper.GetBool("core.sync")
 	conf.Core.FeedbackURL = viper.GetString("core.feedback_hook_url")
 	conf.Core.FeedbackTimeout = int64(viper.GetInt("core.feedback_timeout"))
+	conf.Core.FeedbackHeader = viper.GetStringSlice("core.feedback_header")
 	conf.Core.SSL = viper.GetBool("core.ssl")
 	conf.Core.CertPath = viper.GetString("core.cert_path")
 	conf.Core.KeyPath = viper.GetString("core.key_path")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,6 +55,7 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), "release", suite.ConfGorushDefault.Core.Mode)
 	assert.Equal(suite.T(), false, suite.ConfGorushDefault.Core.Sync)
 	assert.Equal(suite.T(), "", suite.ConfGorushDefault.Core.FeedbackURL)
+	assert.Equal(suite.T(), 0, len(suite.ConfGorushDefault.Core.FeedbackHeader))
 	assert.Equal(suite.T(), int64(10), suite.ConfGorushDefault.Core.FeedbackTimeout)
 	assert.Equal(suite.T(), false, suite.ConfGorushDefault.Core.SSL)
 	assert.Equal(suite.T(), "cert.pem", suite.ConfGorushDefault.Core.CertPath)
@@ -150,6 +151,8 @@ func (suite *ConfigTestSuite) TestValidateConf() {
 	assert.Equal(suite.T(), false, suite.ConfGorush.Core.Sync)
 	assert.Equal(suite.T(), "", suite.ConfGorush.Core.FeedbackURL)
 	assert.Equal(suite.T(), int64(10), suite.ConfGorush.Core.FeedbackTimeout)
+	assert.Equal(suite.T(), 1, len(suite.ConfGorush.Core.FeedbackHeader))
+	assert.Equal(suite.T(), "x-gorush-token:4e989115e09680f44a645519fed6a976", suite.ConfGorush.Core.FeedbackHeader[0])
 	assert.Equal(suite.T(), false, suite.ConfGorush.Core.SSL)
 	assert.Equal(suite.T(), "cert.pem", suite.ConfGorush.Core.CertPath)
 	assert.Equal(suite.T(), "key.pem", suite.ConfGorush.Core.KeyPath)
@@ -228,6 +231,8 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	os.Setenv("GORUSH_IOS_KEY_ID", "ABC123DEFG")
 	os.Setenv("GORUSH_IOS_TEAM_ID", "DEF123GHIJ")
 	os.Setenv("GORUSH_API_HEALTH_URI", "/healthz")
+	os.Setenv("GORUSH_CORE_FEEDBACK_HOOK_URL", "http://example.com")
+	os.Setenv("GORUSH_CORE_FEEDBACK_HEADER", "x-api-key:1234567890 x-auth-key:0987654321")
 	ConfGorush, err := LoadConf("testdata/config.yml")
 	if err != nil {
 		panic("failed to load config.yml from file")
@@ -238,6 +243,9 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	assert.Equal(t, "ABC123DEFG", ConfGorush.Ios.KeyID)
 	assert.Equal(t, "DEF123GHIJ", ConfGorush.Ios.TeamID)
 	assert.Equal(t, "/healthz", ConfGorush.API.HealthURI)
+	assert.Equal(t, "http://example.com", ConfGorush.Core.FeedbackURL)
+	assert.Equal(t, "x-api-key:1234567890", ConfGorush.Core.FeedbackHeader[0])
+	assert.Equal(t, "x-auth-key:0987654321", ConfGorush.Core.FeedbackHeader[1])
 }
 
 func TestLoadWrongDefaultYAMLConfig(t *testing.T) {

--- a/config/testdata/config.yml
+++ b/config/testdata/config.yml
@@ -6,9 +6,14 @@ core:
   worker_num: 0 # default worker number is runtime.NumCPU()
   queue_num: 0 # default queue number is 8192
   max_notification: 100
-  sync: false # set true if you need get error message from fail push notification in API response. It only works when the queue engine is local.
-  feedback_hook_url: "" # set a hook url if you need get error message asynchronously from fail push notification in API response.
+  # set true if you need get error message from fail push notification in API response.
+  # It only works when the queue engine is local.
+  sync: false
+  # set webhook url if you need get error message asynchronously from fail push notification in API response.
+  feedback_hook_url: ""
   feedback_timeout: 10 # default is 10 second
+  feedback_header:
+    - x-gorush-token:4e989115e09680f44a645519fed6a976
   mode: "release"
   ssl: false
   cert_path: "cert.pem"

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/flatbuffers v23.3.3+incompatible // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/klauspost/compress v1.16.3 // indirect
+	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.2 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
-github.com/klauspost/compress v1.16.3 h1:XuJt9zzcnaz6a16/OU53ZjWp/v7/42WcR5t2a0PcNQY=
-github.com/klauspost/compress v1.16.3/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
+github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=

--- a/notify/feedback.go
+++ b/notify/feedback.go
@@ -6,13 +6,26 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/appleboy/gorush/logx"
 )
 
+// extractHeaders converts a slice of strings to a map of strings.
+func extractHeaders(headers []string) map[string]string {
+	result := make(map[string]string)
+	for _, header := range headers {
+		parts := strings.Split(header, ":")
+		if len(parts) == 2 {
+			result[parts[0]] = parts[1]
+		}
+	}
+	return result
+}
+
 // DispatchFeedback sends a feedback to the configured gateway.
-func DispatchFeedback(log logx.LogPushEntry, url string, timeout int64) error {
+func DispatchFeedback(log logx.LogPushEntry, url string, timeout int64, header []string) error {
 	if url == "" {
 		return errors.New("url can't be empty")
 	}
@@ -25,6 +38,11 @@ func DispatchFeedback(log logx.LogPushEntry, url string, timeout int64) error {
 	req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewBuffer(payload))
 	if err != nil {
 		return err
+	}
+
+	headers := extractHeaders(header)
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -255,7 +255,7 @@ func SendNotification(req qcore.QueuedMessage, cfg *config.ConfYaml) (resp *Resp
 
 	if cfg.Core.FeedbackURL != "" {
 		for _, l := range resp.Logs {
-			err := DispatchFeedback(l, cfg.Core.FeedbackURL, cfg.Core.FeedbackTimeout)
+			err := DispatchFeedback(l, cfg.Core.FeedbackURL, cfg.Core.FeedbackTimeout, cfg.Core.FeedbackHeader)
 			if err != nil {
 				logx.LogError.Error(err)
 			}


### PR DESCRIPTION
fix #686 

- Removed `nolint` comment from `config.go`
- Reorganized and added comments for `sync` and `feedback_hook_url` in `config.go`
- Added `feedback_header` to `config.go` and `config.yml`
- Moved `FeedbackURL` and `FeedbackTimeout` in `config.go`
- Updated `github.com/klauspost/compress` version in `go.mod`
- Added `extractHeaders` function in `feedback.go` to convert a slice of strings to a map
- Updated `DispatchFeedback` function in `feedback.go` to include headers
- Updated tests in `feedback_test.go` to include headers in `DispatchFeedback` function calls
- Updated `SendNotification` function in `notification.go` to include headers in `DispatchFeedback` function call