### PR TITLE
Fixed README section about running docker container with custom config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,7 +1214,7 @@ Run `gorush` with your own config file.
 
 ```bash
 docker pull appleboy/gorush
-docker run --name gorush -v ${PWD}/config.yml:/config.yml -p 80:8088 appleboy/gorush
+docker run --name gorush -v ${PWD}/config.yml:/home/gorush/config.yml -p 80:8088 appleboy/gorush
 ```
 
 Testing your gorush server using [httpie](https://github.com/jkbrzt/httpie) command.


### PR DESCRIPTION
I was trying to run the docker image of gorush with custom config file and realized that there's a minor error in documentation regarding this. Please fix this.