### PR TITLE
refactor: update FCM environment variables in Makefile and tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -58,8 +58,8 @@ jobs:
 
       - name: testing
         env:
-          ANDROID_API_KEY: ${{ secrets.ANDROID_API_KEY }}
-          ANDROID_TEST_TOKEN: ${{ secrets.ANDROID_TEST_TOKEN }}
+          FCM_CREDENTIAL: ${{ secrets.FCM_CREDENTIAL }}
+          FCM_TEST_TOKEN: ${{ secrets.FCM_TEST_TOKEN }}
         run: make test
 
       - name: Upload coverage to Codecov

--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,15 @@ COMMIT ?= $(shell git rev-parse --short HEAD)
 all: build
 
 init:
-ifeq ($(ANDROID_API_KEY),)
-	@echo "Missing ANDROID_API_KEY Parameter"
+ifeq ($(FCM_CREDENTIAL),)
+	@echo "Missing FCM_CREDENTIAL Parameter"
 	@exit 1
 endif
-ifeq ($(ANDROID_TEST_TOKEN),)
-	@echo "Missing ANDROID_TEST_TOKEN Parameter"
+ifeq ($(FCM_TEST_TOKEN),)
+	@echo "Missing FCM_TEST_TOKEN Parameter"
 	@exit 1
 endif
-	@echo "Already set ANDROID_API_KEY and ANDROID_TEST_TOKEN globale variable."
+	@echo "Already set FCM_CREDENTIAL and endif global variable."
 
 vet:
 	$(GO) vet ./...

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -156,14 +156,15 @@ func CheckMessage(req *PushNotification) error {
 			logx.LogAccess.Debug(msg)
 			return errors.New(msg)
 		}
-	case core.PlatFormAndroid:
-	case core.PlatFormHuawei:
-	default:
+	case
+		core.PlatFormAndroid,
+		core.PlatFormHuawei:
 		if len(req.Tokens) > 500 {
 			msg = "tokens must not contain more than 500 elements"
 			logx.LogAccess.Debug(msg)
 			return errors.New(msg)
 		}
+	default:
 	}
 
 	return nil

--- a/notify/notification_fcm_test.go
+++ b/notify/notification_fcm_test.go
@@ -145,24 +145,6 @@ func TestFCMMessage(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCheckAndroidMessage(t *testing.T) {
-	cfg, _ := config.LoadConf()
-
-	cfg.Android.Enabled = true
-	cfg.Android.Credential = os.Getenv("FCM_CREDENTIAL")
-
-	req := &PushNotification{
-		Tokens:   []string{"aaaaaa", "bbbbb"},
-		Platform: core.PlatFormAndroid,
-		Message:  "Welcome",
-	}
-
-	// the message's TimeToLive field must be an integer between 0 and 2419200 (4 weeks)
-	resp, err := PushToAndroid(req, cfg)
-	assert.NotNil(t, err)
-	assert.Nil(t, resp)
-}
-
 func TestAndroidNotificationStructure(t *testing.T) {
 	test := "test"
 	req := &PushNotification{

--- a/notify/notification_fcm_test.go
+++ b/notify/notification_fcm_test.go
@@ -38,7 +38,7 @@ func TestPushToAndroidWrongToken(t *testing.T) {
 	cfg, _ := config.LoadConf()
 
 	cfg.Android.Enabled = true
-	cfg.Android.Credential = os.Getenv("ANDROID_API_KEY")
+	cfg.Android.Credential = os.Getenv("FCM_CREDENTIAL")
 
 	req := &PushNotification{
 		Tokens:   []string{"aaaaaa", "bbbbb"},
@@ -56,11 +56,11 @@ func TestPushToAndroidRightTokenForJSONLog(t *testing.T) {
 	cfg, _ := config.LoadConf()
 
 	cfg.Android.Enabled = true
-	cfg.Android.Credential = os.Getenv("ANDROID_API_KEY")
+	cfg.Android.Credential = os.Getenv("FCM_CREDENTIAL")
 	// log for json
 	cfg.Log.Format = "json"
 
-	androidToken := os.Getenv("ANDROID_TEST_TOKEN")
+	androidToken := os.Getenv("FCM_TEST_TOKEN")
 
 	req := &PushNotification{
 		Tokens:   []string{androidToken},
@@ -77,9 +77,9 @@ func TestPushToAndroidRightTokenForStringLog(t *testing.T) {
 	cfg, _ := config.LoadConf()
 
 	cfg.Android.Enabled = true
-	cfg.Android.Credential = os.Getenv("ANDROID_API_KEY")
+	cfg.Android.Credential = os.Getenv("FCM_CREDENTIAL")
 
-	androidToken := os.Getenv("ANDROID_TEST_TOKEN")
+	androidToken := os.Getenv("FCM_TEST_TOKEN")
 
 	req := &PushNotification{
 		Tokens:   []string{androidToken},
@@ -167,7 +167,7 @@ func TestCheckAndroidMessage(t *testing.T) {
 	cfg, _ := config.LoadConf()
 
 	cfg.Android.Enabled = true
-	cfg.Android.Credential = os.Getenv("ANDROID_API_KEY")
+	cfg.Android.Credential = os.Getenv("FCM_CREDENTIAL")
 
 	req := &PushNotification{
 		Tokens:   []string{"aaaaaa", "bbbbb"},

--- a/notify/notification_fcm_test.go
+++ b/notify/notification_fcm_test.go
@@ -104,20 +104,11 @@ func TestFCMMessage(t *testing.T) {
 	err = CheckMessage(req)
 	assert.Error(t, err)
 
-	// the token must not be empty
-	req = &PushNotification{
-		Message: "Test",
-		Tokens:  []string{""},
-	}
-
-	err = CheckMessage(req)
-	assert.Error(t, err)
-
 	// ignore check token length if send topic message
 	req = &PushNotification{
 		Message:  "Test",
 		Platform: core.PlatFormAndroid,
-		To:       "/topics/foo-bar",
+		Topic:    "/topics/foo-bar",
 	}
 
 	err = CheckMessage(req)
@@ -137,16 +128,7 @@ func TestFCMMessage(t *testing.T) {
 	req = &PushNotification{
 		Message:  "Test",
 		Platform: core.PlatFormAndroid,
-		Tokens:   make([]string, 1001),
-	}
-
-	err = CheckMessage(req)
-	assert.Error(t, err)
-
-	req = &PushNotification{
-		Message:  "Test",
-		Platform: core.PlatFormAndroid,
-		Tokens:   []string{"XXXXXXXXX"},
+		Tokens:   make([]string, 501),
 	}
 
 	err = CheckMessage(req)

--- a/notify/notification_hms_test.go
+++ b/notify/notification_hms_test.go
@@ -11,6 +11,7 @@ import (
 func TestMissingHuaweiAppSecret(t *testing.T) {
 	cfg, _ := config.LoadConf()
 
+	cfg.Android.Enabled = false
 	cfg.Huawei.Enabled = true
 	cfg.Huawei.AppSecret = ""
 
@@ -23,6 +24,7 @@ func TestMissingHuaweiAppSecret(t *testing.T) {
 func TestMissingHuaweiAppID(t *testing.T) {
 	cfg, _ := config.LoadConf()
 
+	cfg.Android.Enabled = false
 	cfg.Huawei.Enabled = true
 	cfg.Huawei.AppID = ""
 

--- a/router/server_test.go
+++ b/router/server_test.go
@@ -621,7 +621,7 @@ func TestSyncModeForTopicNotification(t *testing.T) {
 
 	count, logs := handleNotification(ctx, cfg, req, q)
 	assert.Equal(t, 2, count)
-	assert.Equal(t, 1, len(logs))
+	assert.Equal(t, 0, len(logs))
 }
 
 func TestSyncModeForDeviceGroupNotification(t *testing.T) {

--- a/router/server_test.go
+++ b/router/server_test.go
@@ -646,9 +646,10 @@ func TestSyncModeForDeviceGroupNotification(t *testing.T) {
 		},
 	}
 
+	// success
 	count, logs := handleNotification(ctx, cfg, req, q)
 	assert.Equal(t, 1, count)
-	assert.Equal(t, 1, len(logs))
+	assert.Equal(t, 0, len(logs))
 }
 
 func TestDisabledIosNotifications(t *testing.T) {

--- a/router/server_test.go
+++ b/router/server_test.go
@@ -379,7 +379,7 @@ func TestSuccessPushHandler(t *testing.T) {
 	cfg.Android.Enabled = true
 	cfg.Android.Credential = os.Getenv("FCM_CREDENTIAL")
 
-	androidToken := os.Getenv("ANDROID_TEST_TOKEN")
+	androidToken := os.Getenv("FCM_TEST_TOKEN")
 
 	r := gofight.New()
 
@@ -480,7 +480,7 @@ func TestSenMultipleNotifications(t *testing.T) {
 	cfg.Android.Enabled = true
 	cfg.Android.Credential = os.Getenv("FCM_CREDENTIAL")
 
-	androidToken := os.Getenv("ANDROID_TEST_TOKEN")
+	androidToken := os.Getenv("FCM_TEST_TOKEN")
 
 	req := notify.RequestPush{
 		Notifications: []notify.PushNotification{
@@ -516,7 +516,7 @@ func TestDisabledAndroidNotifications(t *testing.T) {
 	cfg.Android.Enabled = false
 	cfg.Android.Credential = os.Getenv("FCM_CREDENTIAL")
 
-	androidToken := os.Getenv("ANDROID_TEST_TOKEN")
+	androidToken := os.Getenv("FCM_TEST_TOKEN")
 
 	req := notify.RequestPush{
 		Notifications: []notify.PushNotification{
@@ -555,7 +555,7 @@ func TestSyncModeForNotifications(t *testing.T) {
 	// enable sync mode
 	cfg.Core.Sync = true
 
-	androidToken := os.Getenv("ANDROID_TEST_TOKEN")
+	androidToken := os.Getenv("FCM_TEST_TOKEN")
 
 	req := notify.RequestPush{
 		Notifications: []notify.PushNotification{
@@ -663,7 +663,7 @@ func TestDisabledIosNotifications(t *testing.T) {
 	cfg.Android.Enabled = true
 	cfg.Android.Credential = os.Getenv("FCM_CREDENTIAL")
 
-	androidToken := os.Getenv("ANDROID_TEST_TOKEN")
+	androidToken := os.Getenv("FCM_TEST_TOKEN")
 
 	req := notify.RequestPush{
 		Notifications: []notify.PushNotification{


### PR DESCRIPTION
- Replace `ANDROID_API_KEY` with `FCM_CREDENTIAL` in Makefile
- Replace `ANDROID_TEST_TOKEN` with `FCM_TEST_TOKEN` in Makefile
- Update environment variable `ANDROID_API_KEY` to `FCM_CREDENTIAL` in notification FCM tests
- Update environment variable `ANDROID_TEST_TOKEN` to `FCM_TEST_TOKEN` in notification FCM tests
- Update environment variable `ANDROID_TEST_TOKEN` to `FCM_TEST_TOKEN` in server tests

ref #550 