### PR TITLE
chore: switch to `appleboy/go-hms-push` library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/apex/gateway v1.1.2
 	github.com/appleboy/gin-status-api v1.1.0
 	github.com/appleboy/go-fcm v1.2.1
+	github.com/appleboy/go-hms-push v1.0.0
 	github.com/appleboy/gofight/v2 v2.1.2
 	github.com/appleboy/graceful v1.1.1
 	github.com/asdine/storm/v3 v3.2.1
@@ -24,7 +25,6 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/msalihkarakasli/go-hms-push v0.0.0-00010101000000-000000000000
 	github.com/prometheus/client_golang v1.19.0
 	github.com/redis/go-redis/v9 v9.5.1
 	github.com/rs/zerolog v1.32.0

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/appleboy/gin-status-api v1.1.0 h1:zoXePlNxk/Aa3Jmh8TI2xX0KTF8iET/QwOM
 github.com/appleboy/gin-status-api v1.1.0/go.mod h1:qUmpFERWhlzRX4Hx+fEznIio8gXAXEDpEnb0Ald1d+g=
 github.com/appleboy/go-fcm v1.2.1 h1:NhpACabtRuAplYg6bTNfSr3LBwsSuutP55HsphzLU/g=
 github.com/appleboy/go-fcm v1.2.1/go.mod h1:5FzMN+9J2sxnkoys9h3y48GQH8HnI637Q/ro/uP2Qsk=
+github.com/appleboy/go-hms-push v1.0.0 h1:qy7/4cvK7PMY/BiHLpoId80Zyy7laY/RvwAt9EG2iWk=
+github.com/appleboy/go-hms-push v1.0.0/go.mod h1:JZzS7XUOFTUV8y+MAnDjOIv0LCZmLmVpJj//Q9t0XBw=
 github.com/appleboy/gofight/v2 v2.1.2 h1:VOy3jow4vIK8BRQJoC/I9muxyYlJ2yb9ht2hZoS3rf4=
 github.com/appleboy/gofight/v2 v2.1.2/go.mod h1:frW+U1QZEdDgixycTj4CygQ48yLTUhplt43+Wczp3rw=
 github.com/appleboy/graceful v1.1.1 h1:vYqfpBdyEFztXofmw9iL8aohnxbcE+2Nq2j67SCoMBo=
@@ -319,8 +321,6 @@ github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIK
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spawn2kill/go-hms-push v0.0.0-20211125124117-e20af53b1304 h1:NFx3I+/cQkqXlnrDzyOAXUDKWFjPQBcO0LSqowMn1Jo=
-github.com/spawn2kill/go-hms-push v0.0.0-20211125124117-e20af53b1304/go.mod h1:4X2lQHsWGt+e3uRK124A6ndq3IIVymTAzEI9A1kIQKc=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=

--- a/notify/global.go
+++ b/notify/global.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/appleboy/go-fcm"
-	"github.com/msalihkarakasli/go-hms-push/push/core"
+	"github.com/appleboy/go-hms-push/push/core"
 	"github.com/sideshow/apns2"
 )
 

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -12,9 +12,9 @@ import (
 	"github.com/appleboy/gorush/logx"
 
 	"firebase.google.com/go/v4/messaging"
+	"github.com/appleboy/go-hms-push/push/model"
 	qcore "github.com/golang-queue/queue/core"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/msalihkarakasli/go-hms-push/push/model"
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary

--- a/notify/notification_hms.go
+++ b/notify/notification_hms.go
@@ -10,9 +10,9 @@ import (
 	"github.com/appleboy/gorush/logx"
 	"github.com/appleboy/gorush/status"
 
-	c "github.com/msalihkarakasli/go-hms-push/push/config"
-	client "github.com/msalihkarakasli/go-hms-push/push/core"
-	"github.com/msalihkarakasli/go-hms-push/push/model"
+	c "github.com/appleboy/go-hms-push/push/config"
+	client "github.com/appleboy/go-hms-push/push/core"
+	"github.com/appleboy/go-hms-push/push/model"
 )
 
 var (


### PR DESCRIPTION
- Replace `msalihkarakasli/go-hms-push` with `appleboy/go-hms-push` in `go.mod`
- Update import paths from `msalihkarakasli/go-hms-push` to `appleboy/go-hms-push` in `global.go`
- Update import paths from `msalihkarakasli/go-hms-push` to `appleboy/go-hms-push` in `notification.go`
- Update import paths from `msalihkarakasli/go-hms-push` to `appleboy/go-hms-push` in `notification_hms.go`

fix #763 