### PR TITLE
refactor(fcm): add context parameter to various functions

### DIFF
--- a/notify/notification.go
+++ b/notify/notification.go
@@ -241,7 +241,7 @@ func SendNotification(
 	case core.PlatFormIos:
 		resp, err = PushToIOS(v, cfg)
 	case core.PlatFormAndroid:
-		resp, err = PushToAndroid(v, cfg)
+		resp, err = PushToAndroid(ctx, v, cfg)
 	case core.PlatFormHuawei:
 		resp, err = PushToHuawei(v, cfg)
 	}

--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -24,7 +24,7 @@ func fileExists(filename string) bool {
 }
 
 // InitFCMClient use for initialize FCM Client.
-func InitFCMClient(cfg *config.ConfYaml) (*fcm.Client, error) {
+func InitFCMClient(ctx context.Context, cfg *config.ConfYaml) (*fcm.Client, error) {
 	var opts []fcm.Option
 
 	credential := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
@@ -47,7 +47,7 @@ func InitFCMClient(cfg *config.ConfYaml) (*fcm.Client, error) {
 	}
 
 	return fcm.NewClient(
-		context.Background(),
+		ctx,
 		opts...,
 	)
 }
@@ -119,7 +119,7 @@ func GetAndroidNotification(req *PushNotification) []*messaging.Message {
 }
 
 // PushToAndroid provide send notification to Android server.
-func PushToAndroid(req *PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
+func PushToAndroid(ctx context.Context, req *PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
 	logx.LogAccess.Debug("Start push notification for Android")
 
 	var (
@@ -140,7 +140,7 @@ func PushToAndroid(req *PushNotification, cfg *config.ConfYaml) (resp *ResponseP
 	}
 
 	resp = &ResponsePush{}
-	client, err = InitFCMClient(cfg)
+	client, err = InitFCMClient(ctx, cfg)
 
 Retry:
 	notification := GetAndroidNotification(req)
@@ -150,7 +150,7 @@ Retry:
 		return resp, err
 	}
 
-	res, err := client.Send(context.Background(), notification...)
+	res, err := client.Send(ctx, notification...)
 	if err != nil {
 		// Send Message error
 		logx.LogError.Error("FCM server send message error: " + err.Error())

--- a/notify/notification_fcm_test.go
+++ b/notify/notification_fcm_test.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -27,7 +28,7 @@ func TestMissingKeyForInitFCMClient(t *testing.T) {
 	cfg, _ := config.LoadConf()
 	cfg.Android.Credential = ""
 	cfg.Android.KeyPath = ""
-	client, err := InitFCMClient(cfg)
+	client, err := InitFCMClient(context.Background(), cfg)
 
 	assert.Nil(t, client)
 	assert.Error(t, err)
@@ -47,7 +48,7 @@ func TestPushToAndroidWrongToken(t *testing.T) {
 	}
 
 	// Android Success count: 0, Failure count: 2
-	resp, err := PushToAndroid(req, cfg)
+	resp, err := PushToAndroid(context.Background(), req, cfg)
 	assert.Nil(t, err)
 	assert.Len(t, resp.Logs, 2)
 }
@@ -68,7 +69,7 @@ func TestPushToAndroidRightTokenForJSONLog(t *testing.T) {
 		Message:  "Welcome",
 	}
 
-	resp, err := PushToAndroid(req, cfg)
+	resp, err := PushToAndroid(context.Background(), req, cfg)
 	assert.Nil(t, err)
 	assert.Len(t, resp.Logs, 0)
 }
@@ -87,7 +88,7 @@ func TestPushToAndroidRightTokenForStringLog(t *testing.T) {
 		Message:  "Welcome",
 	}
 
-	resp, err := PushToAndroid(req, cfg)
+	resp, err := PushToAndroid(context.Background(), req, cfg)
 	assert.Nil(t, err)
 	assert.Len(t, resp.Logs, 0)
 }


### PR DESCRIPTION
- Introduce `graceful.NewManager` initialization in `main.go`
- Modify `pinger` function to accept a context parameter
- Update `PushToAndroid` function to accept a context parameter
- Update `InitFCMClient` function to accept a context parameter
- Replace `context.Background()` with passed context in various functions
- Add context import in `notification_fcm_test.go`