### PR TITLE
refactor(huawei): add context parameter to PushToHuawei function

### DIFF
--- a/main.go
+++ b/main.go
@@ -234,7 +234,7 @@ func main() {
 			return
 		}
 
-		if _, err := notify.PushToHuawei(req, cfg); err != nil {
+		if _, err := notify.PushToHuawei(g.ShutdownContext(), req, cfg); err != nil {
 			return
 		}
 

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -243,7 +243,7 @@ func SendNotification(
 	case core.PlatFormAndroid:
 		resp, err = PushToAndroid(ctx, v, cfg)
 	case core.PlatFormHuawei:
-		resp, err = PushToHuawei(v, cfg)
+		resp, err = PushToHuawei(ctx, v, cfg)
 	}
 
 	if cfg.Core.FeedbackURL != "" {

--- a/notify/notification_hms.go
+++ b/notify/notification_hms.go
@@ -158,7 +158,7 @@ func GetHuaweiNotification(req *PushNotification) (*model.MessageRequest, error)
 }
 
 // PushToHuawei provide send notification to Android server.
-func PushToHuawei(req *PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
+func PushToHuawei(ctx context.Context, req *PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
 	logx.LogAccess.Debug("Start push notification for Huawei")
 
 	var (
@@ -192,7 +192,7 @@ Retry:
 
 	notification, _ := GetHuaweiNotification(req)
 
-	res, err := client.SendMessage(context.Background(), notification)
+	res, err := client.SendMessage(ctx, notification)
 	if err != nil {
 		// Send Message error
 		errLog := logPush(cfg, core.FailedPush, req.Topic, req, err)


### PR DESCRIPTION
- Add context parameter to `PushToHuawei` function calls
- Update `PushToHuawei` function signature to include context parameter
- Replace `context.Background()` with passed context in `SendMessage` call