### PR TITLE
refactor(storage): BoltDB configuration handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/tidwall/tinyqueue v0.1.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
-	go.etcd.io/bbolt v1.3.9 // indirect
+	go.etcd.io/bbolt v1.3.10 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.52.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.52.0 // indirect
 	go.opentelemetry.io/otel v1.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
-go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
-go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=
+go.etcd.io/bbolt v1.3.10 h1:+BqfJTcCzTItrop8mq/lbzL8wSGtj94UO/3U31shqG0=
+go.etcd.io/bbolt v1.3.10/go.mod h1:bK3UQLPJZly7IlNmV7uVHJDxfe5aK9Ll93e/74Y9oEQ=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.52.0 h1:vS1Ao/R55RNV4O7TA2Qopok8yN+X0LIP6RVWLFkprck=

--- a/status/status.go
+++ b/status/status.go
@@ -65,13 +65,18 @@ func InitAppStatus(conf *config.ConfYaml) error {
 	case "redis":
 		store = redis.New(conf)
 	case "boltdb":
-		store = boltdb.New(conf)
+		store = boltdb.New(
+			conf.Stat.BoltDB.Path,
+			conf.Stat.BoltDB.Bucket,
+		)
 	case "buntdb":
 		store = buntdb.New(conf)
 	case "leveldb":
 		store = leveldb.New(conf)
 	case "badger":
-		store = badger.New(conf.Stat.BadgerDB.Path)
+		store = badger.New(
+			conf.Stat.BadgerDB.Path,
+		)
 	default:
 		logx.LogError.Error("storage error: can't find storage driver")
 		return errors.New("can't find storage driver")

--- a/storage/boltdb/boltdb_test.go
+++ b/storage/boltdb/boltdb_test.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/appleboy/gorush/config"
 	"github.com/appleboy/gorush/core"
 
 	"github.com/stretchr/testify/assert"
@@ -13,9 +12,7 @@ import (
 func TestBoltDBEngine(t *testing.T) {
 	var val int64
 
-	cfg, _ := config.LoadConf()
-
-	boltDB := New(cfg)
+	boltDB := New("", "gorush")
 	err := boltDB.Init()
 	assert.Nil(t, err)
 


### PR DESCRIPTION
- Update `go.etcd.io/bbolt` dependency from v1.3.9 to v1.3.10
- Refactor `InitAppStatus` to pass individual BoltDB and BadgerDB configuration parameters instead of the entire config object
- Add `os` package import in `boltdb.go`
- Modify `New` function in `boltdb.go` to accept `dbPath` and `bucket` parameters instead of the entire config object
- Replace `config` field in `Storage` struct with `dbPath` and `bucket` fields
- Update `Init` method in `boltdb.go` to handle empty `dbPath` by setting a default path
- Update `setBoltDB` and `getBoltDB` methods to use `bucket` field instead of accessing it from the config
- Adjust `boltdb_test.go` to create `boltDB` instance with `dbPath` and `bucket` parameters directly