### PR TITLE
refactor(storage): leveldb initialization and dependency handling

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -74,7 +74,9 @@ func InitAppStatus(conf *config.ConfYaml) error {
 			conf.Stat.BuntDB.Path,
 		)
 	case "leveldb":
-		store = leveldb.New(conf)
+		store = leveldb.New(
+			conf.Stat.LevelDB.Path,
+		)
 	case "badger":
 		store = badger.New(
 			conf.Stat.BadgerDB.Path,

--- a/storage/leveldb/leveldb_test.go
+++ b/storage/leveldb/leveldb_test.go
@@ -1,11 +1,9 @@
 package leveldb
 
 import (
-	"os"
 	"sync"
 	"testing"
 
-	"github.com/appleboy/gorush/config"
 	"github.com/appleboy/gorush/core"
 
 	"github.com/stretchr/testify/assert"
@@ -14,16 +12,14 @@ import (
 func TestLevelDBEngine(t *testing.T) {
 	var val int64
 
-	cfg, _ := config.LoadConf()
-
-	if _, err := os.Stat(cfg.Stat.LevelDB.Path); os.IsNotExist(err) {
-		err = os.RemoveAll(cfg.Stat.LevelDB.Path)
-		assert.Nil(t, err)
-	}
-
-	levelDB := New(cfg)
+	levelDB := New("")
 	err := levelDB.Init()
 	assert.Nil(t, err)
+
+	// reset the value of the key to 0
+	levelDB.Set(core.HuaweiSuccessKey, 0)
+	val = levelDB.Get(core.HuaweiSuccessKey)
+	assert.Equal(t, int64(0), val)
 
 	levelDB.Add(core.HuaweiSuccessKey, 10)
 	val = levelDB.Get(core.HuaweiSuccessKey)


### PR DESCRIPTION
- Refactor `leveldb.New` initialization to accept `dbPath` instead of `config`
- Add `os` package import in `leveldb.go`
- Remove `config` dependency from `leveldb` package
- Replace `config` field with `dbPath` in `Storage` struct
- Simplify locking mechanism by directly using `sync.RWMutex` methods
- Add default `dbPath` handling in `Init` method if `dbPath` is empty
- Update `leveldb_test.go` to use new `New` function signature
- Add test assertions to reset and verify key values in `leveldb_test.go`