### PR TITLE
refactor(fcm): test Android notification handling

### DIFF
--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -96,9 +96,8 @@ func GetAndroidNotification(req *PushNotification) []*messaging.Message {
 			case string:
 				data[k] = fmt.Sprintf("%s", v)
 			default:
-				jsonValue, err := json.Marshal(v)
-				if err == nil {
-					data[k] = string(jsonValue)
+				if v, err := json.Marshal(v); err == nil {
+					data[k] = string(v)
 				}
 			}
 		}

--- a/notify/notification_fcm_test.go
+++ b/notify/notification_fcm_test.go
@@ -159,6 +159,10 @@ func TestAndroidNotificationStructure(t *testing.T) {
 		Data: D{
 			"a": "1",
 			"b": 2,
+			"json": map[string]interface{}{
+				"c": "3",
+				"d": 4,
+			},
 		},
 		Notification: &messaging.Notification{
 			Title: test,
@@ -172,6 +176,7 @@ func TestAndroidNotificationStructure(t *testing.T) {
 	assert.Equal(t, "Welcome", messages[0].Notification.Body)
 	assert.Equal(t, "1", messages[0].Data["a"])
 	assert.Equal(t, "2", messages[0].Data["b"])
+	assert.Equal(t, "{\"c\":\"3\",\"d\":4}", messages[0].Data["json"])
 
 	// test empty body
 	req = &PushNotification{


### PR DESCRIPTION
- Refactor JSON marshaling logic in `GetAndroidNotification` function
- Add test case for JSON data structure in `TestAndroidNotificationStructure` function

fix #784 