### PR TITLE
chore(queue): add size param for redis queue engine

### DIFF
--- a/main.go
+++ b/main.go
@@ -333,6 +333,7 @@ func main() {
 			redisdb.WithStreamName(cfg.Queue.Redis.StreamName),
 			redisdb.WithGroup(cfg.Queue.Redis.Group),
 			redisdb.WithConsumer(cfg.Queue.Redis.Consumer),
+			redisdb.WithMaxLength(cfg.Core.QueueNum),
 			redisdb.WithRunFunc(notify.Run(cfg)),
 			redisdb.WithLogger(logx.QueueLogger()),
 		)


### PR DESCRIPTION
This parameter can be painlessly applied to redis queues too.
The absence of this parameter causes the stream to grow endlessly.