### PR TITLE
chore(fcm): notification handling logic for sound field

### DIFF
--- a/notify/notification.go
+++ b/notify/notification.go
@@ -115,7 +115,6 @@ type PushNotification struct {
 
 	// ref: https://github.com/sideshow/apns2/blob/54928d6193dfe300b6b88dad72b7e2ae138d4f0a/payload/builder.go#L7-L24
 	InterruptionLevel string `json:"interruption_level,omitempty"`
-	IsGRPC            bool   `json:"is_grpc,omitempty"`
 }
 
 // Bytes for queue message

--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -74,18 +74,23 @@ func GetAndroidNotification(req *PushNotification) []*messaging.Message {
 	}
 
 	// Check if the notification has a sound
-	if req.Sound != "" && req.IsGRPC {
-		req.APNS = &messaging.APNSConfig{
-			Payload: &messaging.APNSPayload{
-				Aps: &messaging.Aps{
+	if req.Sound != "" {
+		if req.APNS == nil {
+			req.APNS = &messaging.APNSConfig{
+				Payload: &messaging.APNSPayload{
+					Aps: &messaging.Aps{
+						Sound: req.Sound.(string),
+					},
+				},
+			}
+		}
+
+		if req.Android == nil {
+			req.Android = &messaging.AndroidConfig{
+				Notification: &messaging.AndroidNotification{
 					Sound: req.Sound.(string),
 				},
-			},
-		}
-		req.Android = &messaging.AndroidConfig{
-			Notification: &messaging.AndroidNotification{
-				Sound: req.Sound.(string),
-			},
+			}
 		}
 	}
 

--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -74,21 +74,23 @@ func GetAndroidNotification(req *PushNotification) []*messaging.Message {
 	}
 
 	// Check if the notification has a sound
-	if req.Sound != "" {
-		if req.APNS == nil {
+	if req.Sound != nil {
+		sound, ok := req.Sound.(string)
+
+		if req.APNS == nil && ok {
 			req.APNS = &messaging.APNSConfig{
 				Payload: &messaging.APNSPayload{
 					Aps: &messaging.Aps{
-						Sound: req.Sound.(string),
+						Sound: sound,
 					},
 				},
 			}
 		}
 
-		if req.Android == nil {
+		if req.Android == nil && ok {
 			req.Android = &messaging.AndroidConfig{
 				Notification: &messaging.AndroidNotification{
-					Sound: req.Sound.(string),
+					Sound: sound,
 				},
 			}
 		}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -79,7 +79,6 @@ func (s *Server) Send(ctx context.Context, in *proto.NotificationRequest) (*prot
 		Priority:         strings.ToLower(in.GetPriority().String()),
 		PushType:         in.PushType,
 		Development:      in.Development,
-		IsGRPC:           true,
 	}
 
 	if badge > 0 {


### PR DESCRIPTION
- Remove `IsGRPC` field from `PushNotification` struct
- Simplify condition by removing `IsGRPC` check in `GetAndroidNotification`
- Add checks for `APNS` and `Android` fields in `GetAndroidNotification`
- Remove `IsGRPC` initialization in `Send` method of `Server`

fix #795 