### PR TITLE
fix(gRPC): create new context to avoid context cancel

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -109,6 +109,7 @@ func (s *Server) Send(ctx context.Context, in *proto.NotificationRequest) (*prot
 	}
 
 	go func() {
+		ctx := context.Background()
 		_, err := notify.SendNotification(ctx, &notification, s.cfg)
 		if err != nil {
 			logx.LogError.Error(err)


### PR DESCRIPTION
- Initialize a new background context in the `Send` function

fix https://github.com/appleboy/gorush/issues/790
fix https://github.com/appleboy/gorush/issues/789