### PR TITLE
feature[iOS]:  Add support to live-activity notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,11 @@ The Request body must have a notifications array. The following is a parameter t
 | mutable_content         | bool         | enable Notification Service app extension.                                                        | -        | only iOS(10.0+).                                              |
 | name                    | string       | sets the name value on the aps sound dictionary.                                                  | -        | only iOS                                                      |
 | volume                  | float32      | sets the volume value on the aps sound dictionary.                                                | -        | only iOS                                                      |
-| interruption_level      | string       | defines the interruption level for the push notification.                                         | -        | only iOS(15.0+)                                                      |
+| interruption_level      | string       | defines the interruption level for the push notification.                                         | -        | only iOS(15.0+)                                               |
+| content-state           | string array | dynamic and custom content for live-activity notification.                                        | -        | only iOS(16.1+)                                               |
+| timestamp               | int          | the UNIX time when sending the remote notification that updates or ends a Live Activity           | -        | only iOS(16.1+)                                               |                                            
+| event                   | string       | describes whether you update or end an ongoing Live Activity                                      | -        | only iOS(16.1+)                                               |     
+| stale-date              | int          | the date which a Live Activity becomes stale, or out of date                                      | -        | only iOS(16.1+)                                               |
 
 ### iOS alert payload
 

--- a/README.md
+++ b/README.md
@@ -726,6 +726,7 @@ The Request body must have a notifications array. The following is a parameter t
 | timestamp               | int          | the UNIX time when sending the remote notification that updates or ends a Live Activity           | -        | only iOS(16.1+)                                               |                                            
 | event                   | string       | describes whether you update or end an ongoing Live Activity                                      | -        | only iOS(16.1+)                                               |     
 | stale-date              | int          | the date which a Live Activity becomes stale, or out of date                                      | -        | only iOS(16.1+)                                               |
+| dismissal-date          | int          | the UNIX time -timestamp- which a Live Activity will end and will be removed                      | -        | only iOS(16.1+)                                               |
 
 ### iOS alert payload
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0
 	github.com/redis/go-redis/v9 v9.5.3
 	github.com/rs/zerolog v1.32.0
-	github.com/sideshow/apns2 v0.23.0
+	github.com/sideshow/apns2 v0.24.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgY
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/sideshow/apns2 v0.23.0 h1:lpkikaZ995GIcKk6AFsYzHyezCrsrfEDvUWcWkEGErY=
-github.com/sideshow/apns2 v0.23.0/go.mod h1:7Fceu+sL0XscxrfLSkAoH6UtvKefq3Kq1n4W3ayQZqE=
+github.com/sideshow/apns2 v0.24.0 h1:syofL4rd8ZeqUVySgYyBSYr/oLMU/HzJi++r3FIp6Z4=
+github.com/sideshow/apns2 v0.24.0/go.mod h1:7Fceu+sL0XscxrfLSkAoH6UtvKefq3Kq1n4W3ayQZqE=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -118,10 +118,11 @@ type PushNotification struct {
 
 	// live-activity support
 	// ref: https://developer.apple.com/documentation/activitykit/updating-and-ending-your-live-activity-with-activitykit-push-notifications
-	ContentState D      `json:"content-state,omitempty"`
-	StaleDate    int64  `json:"stale-date,omitempty"`
-	Event        string `json:"event,omitempty"`
-	Timestamp    int64  `json:"timestamp,omitempty"`
+	ContentState  D      `json:"content-state,omitempty"`
+	StaleDate     int64  `json:"stale-date,omitempty"`
+	DismissalDate int64  `json:"dismissal-date"`
+	Event         string `json:"event,omitempty"`
+	Timestamp     int64  `json:"timestamp,omitempty"`
 }
 
 // Bytes for queue message

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -115,6 +115,10 @@ type PushNotification struct {
 
 	// ref: https://github.com/sideshow/apns2/blob/54928d6193dfe300b6b88dad72b7e2ae138d4f0a/payload/builder.go#L7-L24
 	InterruptionLevel string `json:"interruption_level,omitempty"`
+	ContentState      D      `json:"content-state,omitempty"`
+	StaleDate         int64  `json:"stale-date,omitempty"`
+	Event             string `json:"event,omitempty"`
+	Timestamp         int64  `json:"timestamp,omitempty"`
 }
 
 // Bytes for queue message

--- a/notify/notification.go
+++ b/notify/notification.go
@@ -115,10 +115,13 @@ type PushNotification struct {
 
 	// ref: https://github.com/sideshow/apns2/blob/54928d6193dfe300b6b88dad72b7e2ae138d4f0a/payload/builder.go#L7-L24
 	InterruptionLevel string `json:"interruption_level,omitempty"`
-	ContentState      D      `json:"content-state,omitempty"`
-	StaleDate         int64  `json:"stale-date,omitempty"`
-	Event             string `json:"event,omitempty"`
-	Timestamp         int64  `json:"timestamp,omitempty"`
+
+	// live-activity support
+	// ref: https://developer.apple.com/documentation/activitykit/updating-and-ending-your-live-activity-with-activitykit-push-notifications
+	ContentState D      `json:"content-state,omitempty"`
+	StaleDate    int64  `json:"stale-date,omitempty"`
+	Event        string `json:"event,omitempty"`
+	Timestamp    int64  `json:"timestamp,omitempty"`
 }
 
 // Bytes for queue message

--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -304,6 +304,10 @@ func iosAlertDictionary(notificationPayload *payload.Payload, req *PushNotificat
 		notificationPayload.StaleDate(req.StaleDate)
 	}
 
+	if req.DismissalDate > 0 {
+		notificationPayload.DismissalDate(req.DismissalDate)
+	}
+
 	if len(req.Event) > 0 {
 		notificationPayload.Event(req.Event)
 	}

--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -295,7 +295,7 @@ func iosAlertDictionary(notificationPayload *payload.Payload, req *PushNotificat
 		notificationPayload.AlertSummaryArgCount(req.Alert.SummaryArgCount)
 	}
 
-	// will wait for apns2 library update to reflect new methods
+	// will wait for apns2 library release to reflect new methods in live-activity
 	if len(req.ContentState) > 0 {
 		notificationPayload.ContentState(req.ContentState)
 	}

--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -295,6 +295,23 @@ func iosAlertDictionary(notificationPayload *payload.Payload, req *PushNotificat
 		notificationPayload.AlertSummaryArgCount(req.Alert.SummaryArgCount)
 	}
 
+	// will wait for apns2 library update to reflect new methods
+	if len(req.ContentState) > 0 {
+		notificationPayload.ContentState(req.ContentState)
+	}
+
+	if req.StaleDate > 0 {
+		notificationPayload.StaleDate(req.StaleDate)
+	}
+
+	if len(req.Event) > 0 {
+		notificationPayload.Event(req.Event)
+	}
+
+	if req.Timestamp > 0 {
+		notificationPayload.Timestamp(req.Timestamp)
+	}
+
 	return notificationPayload
 }
 

--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -295,7 +295,6 @@ func iosAlertDictionary(notificationPayload *payload.Payload, req *PushNotificat
 		notificationPayload.AlertSummaryArgCount(req.Alert.SummaryArgCount)
 	}
 
-	// will wait for apns2 library release to reflect new methods in live-activity
 	if len(req.ContentState) > 0 {
 		notificationPayload.ContentState(req.ContentState)
 	}

--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -296,23 +296,23 @@ func iosAlertDictionary(notificationPayload *payload.Payload, req *PushNotificat
 	}
 
 	if len(req.ContentState) > 0 {
-		notificationPayload.ContentState(req.ContentState)
+		notificationPayload.SetContentState(req.ContentState)
 	}
 
 	if req.StaleDate > 0 {
-		notificationPayload.StaleDate(req.StaleDate)
+		notificationPayload.SetStaleDate(req.StaleDate)
 	}
 
 	if req.DismissalDate > 0 {
-		notificationPayload.DismissalDate(req.DismissalDate)
+		notificationPayload.SetDismissalDate(req.DismissalDate)
 	}
 
 	if len(req.Event) > 0 {
-		notificationPayload.Event(req.Event)
+		notificationPayload.SetEvent(payload.ELiveActivityEvent(req.Event))
 	}
 
 	if req.Timestamp > 0 {
-		notificationPayload.Timestamp(req.Timestamp)
+		notificationPayload.SetTimestamp(req.Timestamp)
 	}
 
 	return notificationPayload

--- a/notify/notification_apns_test.go
+++ b/notify/notification_apns_test.go
@@ -516,6 +516,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	unix := time.Now().Unix()
 	stale_date := time.Now().Unix()
 	timeStamp := time.Now().Unix()
+	itemId := float64(12345)
 
 	req := &PushNotification{
 		Message: "Welcome",
@@ -535,12 +536,17 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 		StaleDate:         stale_date,
 		Event:             testMessage,
 		Timestamp:         timeStamp,
+		ContentState: D{
+			"item_id":   itemId,
+			"item_name": testMessage,
+		},
 	}
 
 	notification := GetIOSNotification(req)
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))
+	fmt.Println("data", string(dump))
 
 	if err := json.Unmarshal(data, &dat); err != nil {
 		log.Println(err)
@@ -563,10 +569,10 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	alert := aps["alert"].(map[string]interface{})
 	titleLocArgs := alert["title-loc-args"].([]interface{})
 	locArgs := alert["loc-args"].([]interface{})
+	contentSate := aps["content-state"].(map[string]interface{})
+	contentSateItemId := contentSate["item_id"]
+	contentSateItemName := contentSate["item_name"]
 
-	fmt.Println("data", json.Unmarshal(data, &dat))
-	fmt.Println("testMessage", event)
-	fmt.Println("sataleDate", staleDate)
 	assert.Equal(t, testMessage, action)
 	assert.Equal(t, testMessage, actionLocKey)
 	assert.Equal(t, testMessage, body)
@@ -579,6 +585,13 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	assert.Equal(t, testMessage, event)
 	assert.Equal(t, unix, staleDate)
 	assert.Equal(t, unix, timestamp)
+
+	// extensible contentState content
+	assert.Equal(t, contentSateItemId, itemId)
+	assert.Equal(t, contentSateItemName, testMessage)
+	assert.Contains(t, contentSate, "item_id")
+	assert.Contains(t, contentSate, "item_name")
+
 	assert.Contains(t, titleLocArgs, "a")
 	assert.Contains(t, titleLocArgs, "b")
 	assert.Contains(t, locArgs, "a")

--- a/notify/notification_apns_test.go
+++ b/notify/notification_apns_test.go
@@ -2,14 +2,14 @@ package notify
 
 import (
 	"context"
+	"fmt"
+	"github.com/appleboy/gorush/config"
+	"github.com/appleboy/gorush/status"
 	"log"
 	"net/http"
 	"net/url"
 	"testing"
 	"time"
-
-	"github.com/appleboy/gorush/config"
-	"github.com/appleboy/gorush/status"
 
 	"github.com/buger/jsonparser"
 	"github.com/sideshow/apns2"
@@ -513,6 +513,9 @@ func TestMessageAndTitle(t *testing.T) {
 
 func TestIOSAlertNotificationStructure(t *testing.T) {
 	var dat map[string]interface{}
+	unix := time.Now().Unix()
+	stale_date := time.Now().Unix()
+	timeStamp := time.Now().Unix()
 
 	req := &PushNotification{
 		Message: "Welcome",
@@ -529,6 +532,9 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 			TitleLocKey:  testMessage,
 		},
 		InterruptionLevel: testMessage,
+		StaleDate:         stale_date,
+		Event:             testMessage,
+		Timestamp:         timeStamp,
 	}
 
 	notification := GetIOSNotification(req)
@@ -550,11 +556,17 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	subtitle, _ := jsonparser.GetString(data, "aps", "alert", "subtitle")
 	titleLocKey, _ := jsonparser.GetString(data, "aps", "alert", "title-loc-key")
 	interruptionLevel, _ := jsonparser.GetString(data, "aps", "interruption-level")
+	staleDate, _ := jsonparser.GetInt(data, "aps", "stale-date")
+	event, _ := jsonparser.GetString(data, "aps", "event")
+	timestamp, _ := jsonparser.GetInt(data, "aps", "timestamp")
 	aps := dat["aps"].(map[string]interface{})
 	alert := aps["alert"].(map[string]interface{})
 	titleLocArgs := alert["title-loc-args"].([]interface{})
 	locArgs := alert["loc-args"].([]interface{})
 
+	fmt.Println("data", json.Unmarshal(data, &dat))
+	fmt.Println("testMessage", event)
+	fmt.Println("sataleDate", staleDate)
 	assert.Equal(t, testMessage, action)
 	assert.Equal(t, testMessage, actionLocKey)
 	assert.Equal(t, testMessage, body)
@@ -564,6 +576,9 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	assert.Equal(t, testMessage, subtitle)
 	assert.Equal(t, testMessage, titleLocKey)
 	assert.Equal(t, testMessage, interruptionLevel)
+	assert.Equal(t, testMessage, event)
+	assert.Equal(t, unix, staleDate)
+	assert.Equal(t, unix, timestamp)
 	assert.Contains(t, titleLocArgs, "a")
 	assert.Contains(t, titleLocArgs, "b")
 	assert.Contains(t, locArgs, "a")

--- a/notify/notification_apns_test.go
+++ b/notify/notification_apns_test.go
@@ -515,6 +515,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	var dat map[string]interface{}
 	unix := time.Now().Unix()
 	stale_date := time.Now().Unix()
+	dismissal_date := stale_date + 5
 	timeStamp := time.Now().Unix()
 	itemId := float64(12345)
 
@@ -534,6 +535,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 		},
 		InterruptionLevel: testMessage,
 		StaleDate:         stale_date,
+		DismissalDate: 	   dismissal_date
 		Event:             testMessage,
 		Timestamp:         timeStamp,
 		ContentState: D{
@@ -586,7 +588,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	assert.Equal(t, unix, staleDate)
 	assert.Equal(t, unix, timestamp)
 
-	// extensible contentState content
+	// dynamic contentState content
 	assert.Equal(t, contentSateItemId, itemId)
 	assert.Equal(t, contentSateItemName, testMessage)
 	assert.Contains(t, contentSate, "item_id")

--- a/notify/notification_apns_test.go
+++ b/notify/notification_apns_test.go
@@ -2,14 +2,14 @@ package notify
 
 import (
 	"context"
-	"fmt"
-	"github.com/appleboy/gorush/config"
-	"github.com/appleboy/gorush/status"
 	"log"
 	"net/http"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/appleboy/gorush/config"
+	"github.com/appleboy/gorush/status"
 
 	"github.com/buger/jsonparser"
 	"github.com/sideshow/apns2"
@@ -535,7 +535,7 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 		},
 		InterruptionLevel: testMessage,
 		StaleDate:         stale_date,
-		DismissalDate: 	   dismissal_date
+		DismissalDate:     dismissal_date,
 		Event:             testMessage,
 		Timestamp:         timeStamp,
 		ContentState: D{
@@ -548,7 +548,6 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 
 	dump, _ := json.Marshal(notification.Payload)
 	data := []byte(string(dump))
-	fmt.Println("data", string(dump))
 
 	if err := json.Unmarshal(data, &dat); err != nil {
 		log.Println(err)
@@ -571,9 +570,9 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	alert := aps["alert"].(map[string]interface{})
 	titleLocArgs := alert["title-loc-args"].([]interface{})
 	locArgs := alert["loc-args"].([]interface{})
-	contentSate := aps["content-state"].(map[string]interface{})
-	contentSateItemId := contentSate["item_id"]
-	contentSateItemName := contentSate["item_name"]
+	contentState := aps["content-state"].(map[string]interface{})
+	contentStateItemId := contentState["item_id"]
+	contentStateItemName := contentState["item_name"]
 
 	assert.Equal(t, testMessage, action)
 	assert.Equal(t, testMessage, actionLocKey)
@@ -589,10 +588,10 @@ func TestIOSAlertNotificationStructure(t *testing.T) {
 	assert.Equal(t, unix, timestamp)
 
 	// dynamic contentState content
-	assert.Equal(t, contentSateItemId, itemId)
-	assert.Equal(t, contentSateItemName, testMessage)
-	assert.Contains(t, contentSate, "item_id")
-	assert.Contains(t, contentSate, "item_name")
+	assert.Equal(t, contentStateItemId, itemId)
+	assert.Equal(t, contentStateItemName, testMessage)
+	assert.Contains(t, contentState, "item_id")
+	assert.Contains(t, contentState, "item_name")
 
 	assert.Contains(t, titleLocArgs, "a")
 	assert.Contains(t, titleLocArgs, "b")


### PR DESCRIPTION
## GOAL:

1. Adds **support payload to live-activity** based on apns2 library

- dismissal-date
- stale-date
- timestamp
- even
- content-state


2. Additional NOTES: Recently it was updated APNS2 with similar changes. Waiting new release of that library [sideshow/apns2](https://github.com/sideshow/apns2).  new relase library -> https://github.com/sideshow/apns2/releases/tag/v0.24.0

     PR that support live activity in APNS2 -> https://github.com/sideshow/apns2/pull/219 
    (My PR version to support live activity in APNS2) -> https://github.com/sideshow/apns2/pull/223

4. Updates in Readme  iOS 16 + live activity feature
5. Update _go.mod_ and _go.sum_ to for APNS2 0.24.0 library

## TESTS
Test code coverage
<img width="1701" alt="image" src="https://github.com/user-attachments/assets/137d2f02-b8d7-4c4d-b1ba-e3f29489f800">


Manual testing with curl POST events using https://github.com/GonzaloAvilez/apns2/pull/1 with current suggested changes.
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/972a1ea9-7d9b-4246-89c9-b673a29f26b2">


Test code coverage after using newest version of **_APNS2_** within go modules:
<img width="750" alt="image" src="https://github.com/user-attachments/assets/1533cc48-cfd2-40d4-a75d-8afa93576b12">
