### PR TITLE
fix: initialize FCM client once.

### DIFF
--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -46,10 +46,13 @@ func InitFCMClient(ctx context.Context, cfg *config.ConfYaml) (*fcm.Client, erro
 		return FCMClient, nil
 	}
 
-	return fcm.NewClient(
+	var err error
+	FCMClient, err = fcm.NewClient(
 		ctx,
 		opts...,
 	)
+
+	return FCMClient, err
 }
 
 // GetAndroidNotification use for define Android notification.


### PR DESCRIPTION
The current implementation initializes a new FCM client for each push notification resulting in very high memory usage especially when there are many requests.