### PR TITLE
fix: use mutable content and content available when set.

### DIFF
--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -223,6 +223,13 @@ Retry:
 		return resp, err
 	}
 
+	if req.Development {
+		for i, msg := range messages {
+			m, _ := json.Marshal(msg)
+			logx.LogAccess.Infof("message #%d - %s", i, m)
+		}
+	}
+
 	res, err := client.Send(ctx, messages...)
 	if err != nil {
 		newErr := fmt.Errorf("fcm service send message error: %v", err)

--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -85,29 +85,17 @@ func GetAndroidNotification(req *PushNotification) []*messaging.Message {
 	// content-available is for background notifications and a badge, alert
 	// and sound keys should not be present.
 	// See: https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification
-	if req.Badge == nil && req.Title == "" && req.Message == "" && req.ContentAvailable {
-		if req.Sound != nil {
-			_, ok := req.Sound.(string)
-			if !ok {
-				req.APNS = &messaging.APNSConfig{
-					Headers: map[string]string{
-						"apns-priority": "5",
-					},
-					Payload: &messaging.APNSPayload{
-						Aps: &messaging.Aps{
-							ContentAvailable: req.ContentAvailable,
-						},
-					},
-				}
-			}
-		} else {
-			req.APNS = &messaging.APNSConfig{
-				Payload: &messaging.APNSPayload{
-					Aps: &messaging.Aps{
-						ContentAvailable: req.ContentAvailable,
-					},
+	if req.ContentAvailable {
+		req.APNS = &messaging.APNSConfig{
+			Headers: map[string]string{
+				"apns-priority": "5",
+			},
+			Payload: &messaging.APNSPayload{
+				Aps: &messaging.Aps{
+					ContentAvailable: req.ContentAvailable,
+					CustomData:       req.Data,
 				},
-			}
+			},
 		}
 	}
 

--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -90,6 +90,9 @@ func GetAndroidNotification(req *PushNotification) []*messaging.Message {
 			_, ok := req.Sound.(string)
 			if !ok {
 				req.APNS = &messaging.APNSConfig{
+					Headers: map[string]string{
+						"apns-priority": "5",
+					},
 					Payload: &messaging.APNSPayload{
 						Aps: &messaging.Aps{
 							ContentAvailable: req.ContentAvailable,

--- a/notify/notification_fcm_test.go
+++ b/notify/notification_fcm_test.go
@@ -149,13 +149,13 @@ func TestFCMMessage(t *testing.T) {
 func TestAndroidNotificationStructure(t *testing.T) {
 	test := "test"
 	req := &PushNotification{
-		Tokens:           []string{"a", "b"},
-		Message:          "Welcome",
-		To:               test,
-		Priority:         HIGH,
-		ContentAvailable: true,
-		Title:            test,
-		Sound:            test,
+		Tokens:         []string{"a", "b"},
+		Message:        "Welcome",
+		To:             test,
+		Priority:       HIGH,
+		MutableContent: true,
+		Title:          test,
+		Sound:          test,
 		Data: D{
 			"a": "1",
 			"b": 2,
@@ -177,6 +177,9 @@ func TestAndroidNotificationStructure(t *testing.T) {
 	assert.Equal(t, "1", messages[0].Data["a"])
 	assert.Equal(t, "2", messages[0].Data["b"])
 	assert.Equal(t, "{\"c\":\"3\",\"d\":4}", messages[0].Data["json"])
+	assert.NotNil(t, messages[0].APNS)
+	assert.Equal(t, req.Sound, messages[0].APNS.Payload.Aps.Sound)
+	assert.Equal(t, req.MutableContent, messages[0].APNS.Payload.Aps.MutableContent)
 
 	// test empty body
 	req = &PushNotification{
@@ -189,4 +192,28 @@ func TestAndroidNotificationStructure(t *testing.T) {
 	messages = GetAndroidNotification(req)
 
 	assert.Equal(t, "", messages[0].Notification.Body)
+}
+
+func TestAndroidBackgroundNotificationStructure(t *testing.T) {
+	req := &PushNotification{
+		Tokens:           []string{"a", "b"},
+		Priority:         HIGH,
+		ContentAvailable: true,
+		Data: D{
+			"a": "1",
+			"b": 2,
+			"json": map[string]interface{}{
+				"c": "3",
+				"d": 4,
+			},
+		},
+	}
+
+	messages := GetAndroidNotification(req)
+
+	assert.Equal(t, "1", messages[0].Data["a"])
+	assert.Equal(t, "2", messages[0].Data["b"])
+	assert.Equal(t, "{\"c\":\"3\",\"d\":4}", messages[0].Data["json"])
+	assert.NotNil(t, messages[0].APNS)
+	assert.Equal(t, req.ContentAvailable, messages[0].APNS.Payload.Aps.ContentAvailable)
 }

--- a/notify/notification_fcm_test.go
+++ b/notify/notification_fcm_test.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"context"
 	"os"
+	"reflect"
 	"testing"
 
 	"firebase.google.com/go/v4/messaging"
@@ -195,18 +196,19 @@ func TestAndroidNotificationStructure(t *testing.T) {
 }
 
 func TestAndroidBackgroundNotificationStructure(t *testing.T) {
+	data := map[string]any{
+		"a": "1",
+		"b": 2,
+		"json": map[string]interface{}{
+			"c": "3",
+			"d": 4,
+		},
+	}
 	req := &PushNotification{
 		Tokens:           []string{"a", "b"},
 		Priority:         HIGH,
 		ContentAvailable: true,
-		Data: D{
-			"a": "1",
-			"b": 2,
-			"json": map[string]interface{}{
-				"c": "3",
-				"d": 4,
-			},
-		},
+		Data:             data,
 	}
 
 	messages := GetAndroidNotification(req)
@@ -216,4 +218,5 @@ func TestAndroidBackgroundNotificationStructure(t *testing.T) {
 	assert.Equal(t, "{\"c\":\"3\",\"d\":4}", messages[0].Data["json"])
 	assert.NotNil(t, messages[0].APNS)
 	assert.Equal(t, req.ContentAvailable, messages[0].APNS.Payload.Aps.ContentAvailable)
+	assert.True(t, reflect.DeepEqual(data, messages[0].APNS.Payload.Aps.CustomData))
 }


### PR DESCRIPTION
This PR uses the content available and mutable content fields when set. In the older version e.g 1.4.0 and in the legacy FCM API the content available was set [here](https://github.com/appleboy/gorush/blob/1.4.0/gorush/notification.go#L56) and used here in the [request](https://github.com/appleboy/gorush/blob/1.4.0/gorush/notification.go#L346). It would be good for when these fields are set they can be propagated to Firebase Cloud Messaging under the [APNS Config section](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#ApnsConfig). 

The 2 fields influence how Apple Push Notification system handles the notifications on the end user device.

Content available is for background notifications hence the notification shouldn't have an alert or sound according to this [reference](https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification).
