### PR TITLE
feat: add support for Redis authentication and TLS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ queue:
     group: gorush
     consumer: gorush
     stream_name: gorush
+  redis:
+    addr: 127.0.0.1:6379
+    group: gorush
+    consumer: gorush
+    stream_name: gorush
+    with_tls: false
+    username: ""
+    password: ""
 
 ios:
   enabled: false

--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,9 @@ queue:
     group: gorush
     consumer: gorush
     stream_name: gorush
+    with_tls: false
+    username: ""
+    password: ""
 
 ios:
   enabled: false
@@ -255,9 +258,12 @@ type SectionNATS struct {
 // SectionRedisQueue is sub section of config.
 type SectionRedisQueue struct {
 	Addr       string `yaml:"addr"`
+	Username   string `yaml:"username"`
+	Password   string `yaml:"password"`
 	StreamName string `yaml:"stream_name"`
 	Group      string `yaml:"group"`
 	Consumer   string `yaml:"consumer"`
+	WithTLS    bool   `yaml:"with_tls"`
 }
 
 // SectionRedis is sub section of config.
@@ -424,6 +430,9 @@ func LoadConf(confPath ...string) (*ConfYaml, error) {
 	conf.Queue.Redis.StreamName = viper.GetString("queue.redis.stream_name")
 	conf.Queue.Redis.Group = viper.GetString("queue.redis.group")
 	conf.Queue.Redis.Consumer = viper.GetString("queue.redis.consumer")
+	conf.Queue.Redis.WithTLS = viper.GetBool("queue.redis.with_tls")
+	conf.Queue.Redis.Username = viper.GetString("queue.redis.username")
+	conf.Queue.Redis.Password = viper.GetString("queue.redis.password")
 
 	// Stat Engine
 	conf.Stat.Engine = viper.GetString("stat.engine")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -113,6 +113,9 @@ func (suite *ConfigTestSuite) TestValidateConfDefault() {
 	assert.Equal(suite.T(), "gorush", suite.ConfGorushDefault.Queue.Redis.StreamName)
 	assert.Equal(suite.T(), "gorush", suite.ConfGorushDefault.Queue.Redis.Group)
 	assert.Equal(suite.T(), "gorush", suite.ConfGorushDefault.Queue.Redis.Consumer)
+	assert.Equal(suite.T(), "", suite.ConfGorushDefault.Queue.Redis.Username)
+	assert.Equal(suite.T(), "", suite.ConfGorushDefault.Queue.Redis.Password)
+	assert.Equal(suite.T(), false, suite.ConfGorushDefault.Queue.Redis.WithTLS)
 
 	// log
 	assert.Equal(suite.T(), "string", suite.ConfGorushDefault.Log.Format)

--- a/config/testdata/config.yml
+++ b/config/testdata/config.yml
@@ -70,6 +70,9 @@ queue:
     group: gorush
     consumer: gorush
     stream_name: gorush
+    username: ""
+    password: ""
+    with_tls: false
 
 ios:
   enabled: false

--- a/main.go
+++ b/main.go
@@ -328,14 +328,22 @@ func main() {
 			nats.WithLogger(logx.QueueLogger()),
 		)
 	case core.Redis:
-		w = redisdb.NewWorker(
+		opts := []redisdb.Option{
 			redisdb.WithAddr(cfg.Queue.Redis.Addr),
+			redisdb.WithUsername(cfg.Queue.Redis.Username),
+			redisdb.WithPassword(cfg.Queue.Redis.Password),
 			redisdb.WithStreamName(cfg.Queue.Redis.StreamName),
 			redisdb.WithGroup(cfg.Queue.Redis.Group),
 			redisdb.WithConsumer(cfg.Queue.Redis.Consumer),
 			redisdb.WithMaxLength(cfg.Core.QueueNum),
 			redisdb.WithRunFunc(notify.Run(cfg)),
 			redisdb.WithLogger(logx.QueueLogger()),
+		}
+		if cfg.Queue.Redis.WithTLS {
+			opts = append(opts, redisdb.WithTLS())
+		}
+		w = redisdb.NewWorker(
+			opts...,
 		)
 	default:
 		logx.LogError.Fatalf("we don't support queue engine: %s", cfg.Queue.Engine)


### PR DESCRIPTION
- Add Redis configuration options to README.md
- Add `with_tls`, `username`, and `password` fields to Redis queue configuration in config.go
- Update config.go to load new Redis configuration options using viper
- Add tests for new Redis configuration options in config_test.go
- Add `username`, `password`, and `with_tls` fields to Redis queue configuration in config.yml
- Update main.go to use new Redis configuration options with conditional TLS setup