### PR TITLE
fix: priority not passed through to AndroidConfig for FCM

### DIFF
--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -132,6 +132,7 @@ func GetAndroidNotification(req *PushNotification) []*messaging.Message {
 
 			if req.Android == nil {
 				req.Android = &messaging.AndroidConfig{
+					Priority: req.Priority,
 					Notification: &messaging.AndroidNotification{
 						Sound: sound,
 					},


### PR DESCRIPTION
The `PushNotification.Priority` is never passed through to `AndroidConfig.Priority` and as a result, high priority pushes always come through as normal priority.

We've tested this internally at Muzz with success.