### PR TITLE
refactor: refactor notification delivery for modularity and testability

### DIFF
--- a/notify/notification.go
+++ b/notify/notification.go
@@ -197,45 +197,61 @@ func SetProxy(proxy string) error {
 	return nil
 }
 
+// checkIOSConf validates iOS configuration.
+func checkIOSConf(cfg *config.ConfYaml) error {
+	if !cfg.Ios.Enabled {
+		return nil
+	}
+	if cfg.Ios.KeyPath == "" && cfg.Ios.KeyBase64 == "" {
+		return errors.New("missing iOS certificate key")
+	}
+	if cfg.Ios.KeyPath != "" {
+		if _, err := os.Stat(cfg.Ios.KeyPath); os.IsNotExist(err) {
+			return errors.New("certificate file does not exist")
+		}
+	}
+	return nil
+}
+
+// checkAndroidConf validates Android/FCM configuration.
+func checkAndroidConf(cfg *config.ConfYaml) error {
+	if !cfg.Android.Enabled {
+		return nil
+	}
+	credential := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if cfg.Android.Credential == "" && cfg.Android.KeyPath == "" && credential == "" {
+		return errors.New("missing fcm credential data")
+	}
+	return nil
+}
+
+// checkHuaweiConf validates Huawei/HMS configuration.
+func checkHuaweiConf(cfg *config.ConfYaml) error {
+	if !cfg.Huawei.Enabled {
+		return nil
+	}
+	if cfg.Huawei.AppSecret == "" {
+		return errors.New("missing huawei app secret")
+	}
+	if cfg.Huawei.AppID == "" {
+		return errors.New("missing huawei app id")
+	}
+	return nil
+}
+
 // CheckPushConf provide check your yml config.
 func CheckPushConf(cfg *config.ConfYaml) error {
 	if !cfg.Ios.Enabled && !cfg.Android.Enabled && !cfg.Huawei.Enabled {
 		return errors.New("please enable iOS, Android or Huawei config in yml config")
 	}
 
-	if cfg.Ios.Enabled {
-		if cfg.Ios.KeyPath == "" && cfg.Ios.KeyBase64 == "" {
-			return errors.New("missing iOS certificate key")
-		}
-
-		// check certificate file exist
-		if cfg.Ios.KeyPath != "" {
-			if _, err := os.Stat(cfg.Ios.KeyPath); os.IsNotExist(err) {
-				return errors.New("certificate file does not exist")
-			}
-		}
+	if err := checkIOSConf(cfg); err != nil {
+		return err
 	}
-
-	if cfg.Android.Enabled {
-		credential := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
-		if cfg.Android.Credential == "" &&
-			cfg.Android.KeyPath == "" &&
-			credential == "" {
-			return errors.New("missing fcm credential data")
-		}
+	if err := checkAndroidConf(cfg); err != nil {
+		return err
 	}
-
-	if cfg.Huawei.Enabled {
-		if cfg.Huawei.AppSecret == "" {
-			return errors.New("missing huawei app secret")
-		}
-
-		if cfg.Huawei.AppID == "" {
-			return errors.New("missing huawei app id")
-		}
-	}
-
-	return nil
+	return checkHuaweiConf(cfg)
 }
 
 // SendNotification provide send notification.

--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -58,92 +58,108 @@ type Sound struct {
 	Volume   float32 `json:"volume,omitempty"`
 }
 
+// loadCertFromFile loads certificate or auth key from a file path.
+func loadCertFromFile(keyPath, password string) (tls.Certificate, *ecdsa.PrivateKey, string, error) {
+	var cert tls.Certificate
+	var authKey *ecdsa.PrivateKey
+	var err error
+
+	ext := filepath.Ext(keyPath)
+	switch ext {
+	case dotP12:
+		cert, err = certificate.FromP12File(keyPath, password)
+	case dotPEM:
+		cert, err = certificate.FromPemFile(keyPath, password)
+	case dotP8:
+		authKey, err = token.AuthKeyFromFile(keyPath)
+	default:
+		err = errors.New("wrong certificate key extension")
+	}
+
+	return cert, authKey, ext, err
+}
+
+// loadCertFromBase64 loads certificate or auth key from base64 encoded data.
+func loadCertFromBase64(keyBase64, keyType, password string) (tls.Certificate, *ecdsa.PrivateKey, string, error) {
+	var cert tls.Certificate
+	var authKey *ecdsa.PrivateKey
+
+	ext := "." + keyType
+	key, err := base64.StdEncoding.DecodeString(keyBase64)
+	if err != nil {
+		return cert, nil, ext, err
+	}
+
+	switch ext {
+	case dotP12:
+		cert, err = certificate.FromP12Bytes(key, password)
+	case dotPEM:
+		cert, err = certificate.FromPemBytes(key, password)
+	case dotP8:
+		authKey, err = token.AuthKeyFromBytes(key)
+	default:
+		err = errors.New("wrong certificate key type")
+	}
+
+	return cert, authKey, ext, err
+}
+
+// createAPNSClientWithToken creates an APNS client using a p8 token.
+func createAPNSClientWithToken(cfg *config.ConfYaml, authKey *ecdsa.PrivateKey) (*apns2.Client, error) {
+	if cfg.Ios.KeyID == "" || cfg.Ios.TeamID == "" {
+		return nil, errors.New("you should provide ios.KeyID and ios.TeamID for p8 token")
+	}
+	t := &token.Token{
+		AuthKey: authKey,
+		KeyID:   cfg.Ios.KeyID,
+		TeamID:  cfg.Ios.TeamID,
+	}
+	return newApnsTokenClient(cfg, t)
+}
+
 // InitAPNSClient use for initialize APNs Client.
 func InitAPNSClient(ctx context.Context, cfg *config.ConfYaml) error {
-	if cfg.Ios.Enabled {
-		var err error
-		var authKey *ecdsa.PrivateKey
-		var certificateKey tls.Certificate
-		var ext string
-
-		if cfg.Ios.KeyPath != "" {
-			ext = filepath.Ext(cfg.Ios.KeyPath)
-
-			switch ext {
-			case dotP12:
-				certificateKey, err = certificate.FromP12File(cfg.Ios.KeyPath, cfg.Ios.Password)
-			case dotPEM:
-				certificateKey, err = certificate.FromPemFile(cfg.Ios.KeyPath, cfg.Ios.Password)
-			case dotP8:
-				authKey, err = token.AuthKeyFromFile(cfg.Ios.KeyPath)
-			default:
-				err = errors.New("wrong certificate key extension")
-			}
-
-			if err != nil {
-				logx.LogError.Error("Cert Error:", err.Error())
-
-				return err
-			}
-		} else if cfg.Ios.KeyBase64 != "" {
-			ext = "." + cfg.Ios.KeyType
-			key, err := base64.StdEncoding.DecodeString(cfg.Ios.KeyBase64)
-			if err != nil {
-				logx.LogError.Error("base64 decode error:", err.Error())
-
-				return err
-			}
-			switch ext {
-			case dotP12:
-				certificateKey, err = certificate.FromP12Bytes(key, cfg.Ios.Password)
-			case dotPEM:
-				certificateKey, err = certificate.FromPemBytes(key, cfg.Ios.Password)
-			case dotP8:
-				authKey, err = token.AuthKeyFromBytes(key)
-			default:
-				err = errors.New("wrong certificate key type")
-			}
-
-			if err != nil {
-				logx.LogError.Error("Cert Error:", err.Error())
-
-				return err
-			}
-		}
-
-		if ext == dotP8 {
-			if cfg.Ios.KeyID == "" || cfg.Ios.TeamID == "" {
-				msg := "you should provide ios.KeyID and ios.TeamID for p8 token"
-				logx.LogError.Error(msg)
-				return errors.New(msg)
-			}
-			token := &token.Token{
-				AuthKey: authKey,
-				// KeyID from developer account (Certificates, Identifiers & Profiles -> Keys)
-				KeyID: cfg.Ios.KeyID,
-				// TeamID from developer account (View Account -> Membership)
-				TeamID: cfg.Ios.TeamID,
-			}
-
-			ApnsClient, err = newApnsTokenClient(cfg, token)
-		} else {
-			ApnsClient, err = newApnsClient(cfg, certificateKey)
-		}
-
-		if h2Transport, ok := ApnsClient.HTTPClient.Transport.(*http2.Transport); ok {
-			configureHTTP2ConnHealthCheck(h2Transport)
-		}
-
-		if err != nil {
-			logx.LogError.Error("Transport Error:", err.Error())
-
-			return err
-		}
-
-		doOnce.Do(func() {
-			MaxConcurrentIOSPushes = make(chan struct{}, cfg.Ios.MaxConcurrentPushes)
-		})
+	if !cfg.Ios.Enabled {
+		return nil
 	}
+
+	var (
+		err            error
+		authKey        *ecdsa.PrivateKey
+		certificateKey tls.Certificate
+		ext            string
+	)
+
+	switch {
+	case cfg.Ios.KeyPath != "":
+		certificateKey, authKey, ext, err = loadCertFromFile(cfg.Ios.KeyPath, cfg.Ios.Password)
+	case cfg.Ios.KeyBase64 != "":
+		certificateKey, authKey, ext, err = loadCertFromBase64(cfg.Ios.KeyBase64, cfg.Ios.KeyType, cfg.Ios.Password)
+	}
+
+	if err != nil {
+		logx.LogError.Error("Cert Error:", err.Error())
+		return err
+	}
+
+	if ext == dotP8 {
+		ApnsClient, err = createAPNSClientWithToken(cfg, authKey)
+	} else {
+		ApnsClient, err = newApnsClient(cfg, certificateKey)
+	}
+
+	if err != nil {
+		logx.LogError.Error("Transport Error:", err.Error())
+		return err
+	}
+
+	if h2Transport, ok := ApnsClient.HTTPClient.Transport.(*http2.Transport); ok {
+		configureHTTP2ConnHealthCheck(h2Transport)
+	}
+
+	doOnce.Do(func() {
+		MaxConcurrentIOSPushes = make(chan struct{}, cfg.Ios.MaxConcurrentPushes)
+	})
 
 	return nil
 }
@@ -226,96 +242,166 @@ func configureHTTP2ConnHealthCheck(h2Transport *http2.Transport) {
 	h2Transport.PingTimeout = 1 * time.Second
 }
 
-func iosAlertDictionary(notificationPayload *payload.Payload, req *PushNotification) *payload.Payload {
-	// Alert dictionary
-
+// setAlertTitleAndBody sets the title and body fields on the notification payload.
+func setAlertTitleAndBody(p *payload.Payload, req *PushNotification) {
 	if len(req.Title) > 0 {
-		notificationPayload.AlertTitle(req.Title)
+		p.AlertTitle(req.Title)
 	}
+	if len(req.Message) > 0 && len(req.Title) > 0 {
+		p.AlertBody(req.Message)
+	}
+	if len(req.Alert.Title) > 0 {
+		p.AlertTitle(req.Alert.Title)
+	}
+	if len(req.Alert.Body) > 0 {
+		p.AlertBody(req.Alert.Body)
+	}
+	// Apple Watch & Safari display this string as part of the notification interface.
+	if len(req.Alert.Subtitle) > 0 {
+		p.AlertSubtitle(req.Alert.Subtitle)
+	}
+}
 
+// setAlertLocalization sets localization-related fields on the notification payload.
+func setAlertLocalization(p *payload.Payload, req *PushNotification) {
+	if len(req.Alert.TitleLocKey) > 0 {
+		p.AlertTitleLocKey(req.Alert.TitleLocKey)
+	}
+	if len(req.Alert.TitleLocArgs) > 0 {
+		p.AlertTitleLocArgs(req.Alert.TitleLocArgs)
+	}
+	if len(req.Alert.LocKey) > 0 {
+		p.AlertLocKey(req.Alert.LocKey)
+	}
+	if len(req.Alert.LocArgs) > 0 {
+		p.AlertLocArgs(req.Alert.LocArgs)
+	}
+	if len(req.Alert.ActionLocKey) > 0 {
+		p.AlertActionLocKey(req.Alert.ActionLocKey)
+	}
+}
+
+// setAlertActions sets action and launch image fields on the notification payload.
+func setAlertActions(p *payload.Payload, req *PushNotification) {
+	if len(req.Alert.LaunchImage) > 0 {
+		p.AlertLaunchImage(req.Alert.LaunchImage)
+	}
+	if len(req.Alert.Action) > 0 {
+		p.AlertAction(req.Alert.Action)
+	}
+	if len(req.Alert.SummaryArg) > 0 {
+		p.AlertSummaryArg(req.Alert.SummaryArg)
+	}
+	if req.Alert.SummaryArgCount > 0 {
+		p.AlertSummaryArgCount(req.Alert.SummaryArgCount)
+	}
+}
+
+// setLiveActivityFields sets Live Activity related fields on the notification payload.
+func setLiveActivityFields(p *payload.Payload, req *PushNotification) {
+	if len(req.ContentState) > 0 {
+		p.SetContentState(req.ContentState)
+	}
+	if req.StaleDate > 0 {
+		p.SetStaleDate(req.StaleDate)
+	}
+	if req.DismissalDate > 0 {
+		p.SetDismissalDate(req.DismissalDate)
+	}
+	if len(req.Event) > 0 {
+		p.SetEvent(payload.ELiveActivityEvent(req.Event))
+	}
+	if req.Timestamp > 0 {
+		p.SetTimestamp(req.Timestamp)
+	}
+}
+
+func iosAlertDictionary(notificationPayload *payload.Payload, req *PushNotification) *payload.Payload {
 	if len(req.InterruptionLevel) > 0 {
 		notificationPayload.InterruptionLevel(payload.EInterruptionLevel(req.InterruptionLevel))
 	}
-
-	if len(req.Message) > 0 && len(req.Title) > 0 {
-		notificationPayload.AlertBody(req.Message)
-	}
-
-	if len(req.Alert.Title) > 0 {
-		notificationPayload.AlertTitle(req.Alert.Title)
-	}
-
-	// Apple Watch & Safari display this string as part of the notification interface.
-	if len(req.Alert.Subtitle) > 0 {
-		notificationPayload.AlertSubtitle(req.Alert.Subtitle)
-	}
-
-	if len(req.Alert.TitleLocKey) > 0 {
-		notificationPayload.AlertTitleLocKey(req.Alert.TitleLocKey)
-	}
-
-	if len(req.Alert.LocArgs) > 0 {
-		notificationPayload.AlertLocArgs(req.Alert.LocArgs)
-	}
-
-	if len(req.Alert.TitleLocArgs) > 0 {
-		notificationPayload.AlertTitleLocArgs(req.Alert.TitleLocArgs)
-	}
-
-	if len(req.Alert.Body) > 0 {
-		notificationPayload.AlertBody(req.Alert.Body)
-	}
-
-	if len(req.Alert.LaunchImage) > 0 {
-		notificationPayload.AlertLaunchImage(req.Alert.LaunchImage)
-	}
-
-	if len(req.Alert.LocKey) > 0 {
-		notificationPayload.AlertLocKey(req.Alert.LocKey)
-	}
-
-	if len(req.Alert.Action) > 0 {
-		notificationPayload.AlertAction(req.Alert.Action)
-	}
-
-	if len(req.Alert.ActionLocKey) > 0 {
-		notificationPayload.AlertActionLocKey(req.Alert.ActionLocKey)
-	}
-
-	// General
 	if len(req.Category) > 0 {
 		notificationPayload.Category(req.Category)
 	}
 
-	if len(req.Alert.SummaryArg) > 0 {
-		notificationPayload.AlertSummaryArg(req.Alert.SummaryArg)
-	}
-
-	if req.Alert.SummaryArgCount > 0 {
-		notificationPayload.AlertSummaryArgCount(req.Alert.SummaryArgCount)
-	}
-
-	if len(req.ContentState) > 0 {
-		notificationPayload.SetContentState(req.ContentState)
-	}
-
-	if req.StaleDate > 0 {
-		notificationPayload.SetStaleDate(req.StaleDate)
-	}
-
-	if req.DismissalDate > 0 {
-		notificationPayload.SetDismissalDate(req.DismissalDate)
-	}
-
-	if len(req.Event) > 0 {
-		notificationPayload.SetEvent(payload.ELiveActivityEvent(req.Event))
-	}
-
-	if req.Timestamp > 0 {
-		notificationPayload.SetTimestamp(req.Timestamp)
-	}
+	setAlertTitleAndBody(notificationPayload, req)
+	setAlertLocalization(notificationPayload, req)
+	setAlertActions(notificationPayload, req)
+	setLiveActivityFields(notificationPayload, req)
 
 	return notificationPayload
+}
+
+// setNotificationPriority sets the priority on the notification based on the request.
+func setNotificationPriority(notification *apns2.Notification, priority string) {
+	if len(priority) == 0 {
+		return
+	}
+	switch priority {
+	case "normal":
+		notification.Priority = apns2.PriorityLow
+	case "high":
+		notification.Priority = apns2.PriorityHigh
+	}
+}
+
+// setPayloadSound sets the sound on the payload based on the request.
+func setPayloadSound(p *payload.Payload, req *PushNotification) {
+	switch req.Sound.(type) {
+	case map[string]interface{}:
+		result := &Sound{}
+		_ = mapstructure.Decode(req.Sound, &result)
+		p.Sound(result)
+	case string:
+		p.Sound(&req.Sound)
+	case Sound:
+		p.Sound(&req.Sound)
+	}
+	if len(req.SoundName) > 0 {
+		p.SoundName(req.SoundName)
+	}
+	if req.SoundVolume > 0 {
+		p.SoundVolume(req.SoundVolume)
+	}
+}
+
+// buildIOSPayload constructs the payload for an iOS notification.
+func buildIOSPayload(req *PushNotification) *payload.Payload {
+	p := payload.NewPayload()
+
+	// add alert object if message length > 0 and title is empty
+	if len(req.Message) > 0 && req.Title == "" {
+		p.Alert(req.Message)
+	}
+
+	// zero value for clear the badge on the app icon.
+	if req.Badge != nil && *req.Badge >= 0 {
+		p.Badge(*req.Badge)
+	}
+
+	if req.MutableContent {
+		p.MutableContent()
+	}
+
+	setPayloadSound(p, req)
+
+	if req.ContentAvailable {
+		p.ContentAvailable()
+	}
+
+	if len(req.URLArgs) > 0 {
+		p.URLArgs(req.URLArgs)
+	}
+
+	if len(req.ThreadID) > 0 {
+		p.ThreadID(req.ThreadID)
+	}
+
+	for k, v := range req.Data {
+		p.Custom(k, v)
+	}
+
+	return iosAlertDictionary(p, req)
 }
 
 // GetIOSNotification use for define iOS notification.
@@ -332,75 +418,13 @@ func GetIOSNotification(req *PushNotification) *apns2.Notification {
 		notification.Expiration = time.Unix(*req.Expiration, 0)
 	}
 
-	if len(req.Priority) > 0 {
-		switch req.Priority {
-		case "normal":
-			notification.Priority = apns2.PriorityLow
-		case "high": // Assuming the original HIGH constant meant "high"
-			notification.Priority = apns2.PriorityHigh
-		}
-	}
+	setNotificationPriority(notification, req.Priority)
 
 	if len(req.PushType) > 0 {
 		notification.PushType = apns2.EPushType(req.PushType)
 	}
 
-	payload := payload.NewPayload()
-
-	// add alert object if message length > 0 and title is empty
-	if len(req.Message) > 0 && req.Title == "" {
-		payload.Alert(req.Message)
-	}
-
-	// zero value for clear the badge on the app icon.
-	if req.Badge != nil && *req.Badge >= 0 {
-		payload.Badge(*req.Badge)
-	}
-
-	if req.MutableContent {
-		payload.MutableContent()
-	}
-
-	switch req.Sound.(type) {
-	// from http request binding
-	case map[string]interface{}:
-		result := &Sound{}
-		_ = mapstructure.Decode(req.Sound, &result)
-		payload.Sound(result)
-	// from http request binding for non critical alerts
-	case string:
-		payload.Sound(&req.Sound)
-	case Sound:
-		payload.Sound(&req.Sound)
-	}
-
-	if len(req.SoundName) > 0 {
-		payload.SoundName(req.SoundName)
-	}
-
-	if req.SoundVolume > 0 {
-		payload.SoundVolume(req.SoundVolume)
-	}
-
-	if req.ContentAvailable {
-		payload.ContentAvailable()
-	}
-
-	if len(req.URLArgs) > 0 {
-		payload.URLArgs(req.URLArgs)
-	}
-
-	if len(req.ThreadID) > 0 {
-		payload.ThreadID(req.ThreadID)
-	}
-
-	for k, v := range req.Data {
-		payload.Custom(k, v)
-	}
-
-	payload = iosAlertDictionary(payload, req)
-
-	notification.Payload = payload
+	notification.Payload = buildIOSPayload(req)
 
 	return notification
 }

--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -55,231 +55,188 @@ func InitFCMClient(ctx context.Context, cfg *config.ConfYaml) (*fcm.Client, erro
 	return FCMClient, err
 }
 
+// setupFCMNotification sets up the notification fields on the request.
+func setupFCMNotification(req *PushNotification) {
+	if req.Title == "" && req.Message == "" && req.Image == "" {
+		return
+	}
+	if req.Notification == nil {
+		req.Notification = &messaging.Notification{}
+	}
+	if req.Title != "" {
+		req.Notification.Title = req.Title
+	}
+	if req.Message != "" {
+		req.Notification.Body = req.Message
+	}
+	if req.Image != "" {
+		req.Notification.ImageURL = req.Image
+	}
+	if req.MutableContent {
+		req.APNS = &messaging.APNSConfig{
+			Payload: &messaging.APNSPayload{
+				Aps: &messaging.Aps{
+					MutableContent: req.MutableContent,
+				},
+			},
+		}
+	}
+}
+
+// setupFCMContentAvailable sets up the content available config for background notifications.
+func setupFCMContentAvailable(req *PushNotification) {
+	if !req.ContentAvailable {
+		return
+	}
+	req.APNS = &messaging.APNSConfig{
+		Headers: map[string]string{
+			"apns-priority": "5",
+		},
+		Payload: &messaging.APNSPayload{
+			Aps: &messaging.Aps{
+				ContentAvailable: req.ContentAvailable,
+				CustomData:       req.Data,
+			},
+		},
+	}
+}
+
+// setAPNSSound sets the sound on the APNS config, initializing nested structs as needed.
+func setAPNSSound(req *PushNotification, sound string) {
+	switch {
+	case req.APNS == nil:
+		req.APNS = &messaging.APNSConfig{
+			Payload: &messaging.APNSPayload{
+				Aps: &messaging.Aps{Sound: sound},
+			},
+		}
+	case req.APNS.Payload == nil:
+		req.APNS.Payload = &messaging.APNSPayload{
+			Aps: &messaging.Aps{Sound: sound},
+		}
+	case req.APNS.Payload.Aps == nil:
+		req.APNS.Payload.Aps = &messaging.Aps{Sound: sound}
+	default:
+		req.APNS.Payload.Aps.Sound = sound
+	}
+}
+
+// setupFCMSound sets up the sound configuration for FCM notifications.
+func setupFCMSound(req *PushNotification) {
+	if req.Sound == nil {
+		return
+	}
+	sound, ok := req.Sound.(string)
+	if !ok {
+		return
+	}
+	setAPNSSound(req, sound)
+	if req.Android == nil {
+		req.Android = &messaging.AndroidConfig{
+			Priority: req.Priority,
+			Notification: &messaging.AndroidNotification{
+				Sound: sound,
+			},
+		}
+	}
+}
+
+// convertDataToStringMap converts the request data to a string map.
+func convertDataToStringMap(data map[string]interface{}) map[string]string {
+	if len(data) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(data))
+	for k, v := range data {
+		switch v.(type) {
+		case string:
+			result[k] = fmt.Sprintf("%s", v)
+		default:
+			if b, err := json.Marshal(v); err == nil {
+				result[k] = string(b)
+			}
+		}
+	}
+	return result
+}
+
+// buildFCMMessage creates a new FCM message with common fields.
+func buildFCMMessage(req *PushNotification, data map[string]string) *messaging.Message {
+	msg := &messaging.Message{
+		Notification: req.Notification,
+		Android:      req.Android,
+		Webpush:      req.Webpush,
+		APNS:         req.APNS,
+		FCMOptions:   req.FCMOptions,
+	}
+	if len(data) > 0 {
+		msg.Data = data
+	}
+	return msg
+}
+
 // GetAndroidNotification use for define Android notification.
 // HTTP Connection Server Reference for Android
 // https://firebase.google.com/docs/cloud-messaging/http-server-ref
 func GetAndroidNotification(req *PushNotification) []*messaging.Message {
+	setupFCMNotification(req)
+	setupFCMContentAvailable(req)
+	setupFCMSound(req)
+
+	data := convertDataToStringMap(req.Data)
 	var messages []*messaging.Message
 
-	if req.Title != "" || req.Message != "" || req.Image != "" {
-		if req.Notification == nil {
-			req.Notification = &messaging.Notification{}
-		}
-		if req.Title != "" {
-			req.Notification.Title = req.Title
-		}
-		if req.Message != "" {
-			req.Notification.Body = req.Message
-		}
-		if req.Image != "" {
-			req.Notification.ImageURL = req.Image
-		}
-		if req.MutableContent {
-			req.APNS = &messaging.APNSConfig{
-				Payload: &messaging.APNSPayload{
-					Aps: &messaging.Aps{
-						MutableContent: req.MutableContent,
-					},
-				},
-			}
-		}
-	}
-
-	// content-available is for background notifications and a badge, alert
-	// and sound keys should not be present.
-	// See: https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification
-	if req.ContentAvailable {
-		req.APNS = &messaging.APNSConfig{
-			Headers: map[string]string{
-				"apns-priority": "5",
-			},
-			Payload: &messaging.APNSPayload{
-				Aps: &messaging.Aps{
-					ContentAvailable: req.ContentAvailable,
-					CustomData:       req.Data,
-				},
-			},
-		}
-	}
-
-	// Check if the notification has a sound
-	if req.Sound != nil {
-		sound, ok := req.Sound.(string)
-		if ok {
-			switch {
-			case req.APNS == nil:
-				req.APNS = &messaging.APNSConfig{
-					Payload: &messaging.APNSPayload{
-						Aps: &messaging.Aps{
-							Sound: sound,
-						},
-					},
-				}
-			case req.APNS.Payload == nil:
-				req.APNS.Payload = &messaging.APNSPayload{
-					Aps: &messaging.Aps{
-						Sound: sound,
-					},
-				}
-
-			case req.APNS.Payload.Aps == nil:
-				req.APNS.Payload.Aps = &messaging.Aps{
-					Sound: sound,
-				}
-			default:
-				req.APNS.Payload.Aps.Sound = sound
-			}
-
-			if req.Android == nil {
-				req.Android = &messaging.AndroidConfig{
-					Priority: req.Priority,
-					Notification: &messaging.AndroidNotification{
-						Sound: sound,
-					},
-				}
-			}
-		}
-	}
-
-	var data map[string]string
-	if len(req.Data) > 0 {
-		data = make(map[string]string, len(req.Data))
-		for k, v := range req.Data {
-			switch v.(type) {
-			case string:
-				data[k] = fmt.Sprintf("%s", v)
-			default:
-				if v, err := json.Marshal(v); err == nil {
-					data[k] = string(v)
-				}
-			}
-		}
-	}
-
-	// Check if the notification is a topic
 	if req.IsTopic() {
-		message := &messaging.Message{
-			Notification: req.Notification,
-			Android:      req.Android,
-			Webpush:      req.Webpush,
-			APNS:         req.APNS,
-			FCMOptions:   req.FCMOptions,
-			Topic:        req.Topic,
-			Condition:    req.Condition,
-		}
-
-		// Add another field
-		if len(req.Data) > 0 {
-			message.Data = data
-		}
-
-		messages = append(messages, message)
+		msg := buildFCMMessage(req, data)
+		msg.Topic = req.Topic
+		msg.Condition = req.Condition
+		messages = append(messages, msg)
 	}
 
-	// Loop through the tokens and create a message for each one
 	for _, token := range req.Tokens {
-		message := &messaging.Message{
-			Token:        token,
-			Notification: req.Notification,
-			Android:      req.Android,
-			Webpush:      req.Webpush,
-			APNS:         req.APNS,
-			FCMOptions:   req.FCMOptions,
-		}
-
-		// Add another field
-		if len(req.Data) > 0 {
-			message.Data = data
-		}
-
-		messages = append(messages, message)
+		msg := buildFCMMessage(req, data)
+		msg.Token = token
+		messages = append(messages, msg)
 	}
 
 	return messages
 }
 
-// PushToAndroid provide send notification to Android server.
-func PushToAndroid(ctx context.Context, req *PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
-	logx.LogAccess.Debug("Start push notification for Android")
-
-	var (
-		client     *fcm.Client
-		retryCount = 0
-		maxRetry   = cfg.Android.MaxRetry
-	)
-
-	if req.Retry > 0 && req.Retry < maxRetry {
-		maxRetry = req.Retry
+// handleTopicResponse processes the topic message response and returns whether to retry.
+func handleTopicResponse(
+	cfg *config.ConfYaml, req *PushNotification, res *messaging.BatchResponse, resp *ResponsePush,
+) bool {
+	if !req.IsTopic() {
+		return false
 	}
 
-	// check message
-	err = CheckMessage(req)
-	if err != nil {
-		logx.LogError.Error("request error: " + err.Error())
-		return nil, err
+	to := req.Topic
+	if req.Condition != "" {
+		to = req.Condition
+	}
+	logx.LogAccess.Debug("Send Topic Message: ", to)
+
+	topicResp := res.Responses[0]
+	if topicResp.Success {
+		logPush(cfg, core.SucceededPush, to, req, nil)
 	}
 
-	resp = &ResponsePush{}
-	client, err = InitFCMClient(ctx, cfg)
-
-Retry:
-	messages := GetAndroidNotification(req)
-	if err != nil {
-		// FCM server error
-		logx.LogError.Error("FCM server error: " + err.Error())
-		return resp, err
-	}
-
-	if req.Development {
-		for i, msg := range messages {
-			m, _ := json.Marshal(msg)
-			logx.LogAccess.Infof("message #%d - %s", i, m)
-		}
-	}
-
-	res, err := client.Send(ctx, messages...)
-	if err != nil {
-		newErr := fmt.Errorf("fcm service send message error: %v", err)
-		logx.LogError.Error(newErr)
-		errLog := logPush(cfg, core.FailedPush, "", req, newErr)
-		resp.Logs = append(resp.Logs, errLog)
-		status.StatStorage.AddAndroidError(1)
-
-		return resp, newErr
-	}
-
-	logx.LogAccess.Debug(fmt.Sprintf("Android Success count: %d, Failure count: %d", res.SuccessCount, res.FailureCount))
-	status.StatStorage.AddAndroidSuccess(int64(res.SuccessCount))
-	status.StatStorage.AddAndroidError(int64(res.FailureCount))
-
-	// result from Send messages to topics
 	retryTopic := false
-	if req.IsTopic() {
-		to := ""
-		if req.Topic != "" {
-			to = req.Topic
-		}
-		if req.Condition != "" {
-			to = req.Condition
-		}
-		logx.LogAccess.Debug("Send Topic Message: ", to)
-
-		newResp := res.Responses[0]
-		if newResp.Success {
-			logPush(cfg, core.SucceededPush, to, req, nil)
-		}
-
-		if newResp.Error != nil {
-			// failure
-			errLog := logPush(cfg, core.FailedPush, to, req, newResp.Error)
-			resp.Logs = append(resp.Logs, errLog)
-			retryTopic = true
-		}
-
-		// remove the first response
-		res.Responses = res.Responses[1:]
+	if topicResp.Error != nil {
+		errLog := logPush(cfg, core.FailedPush, to, req, topicResp.Error)
+		resp.Logs = append(resp.Logs, errLog)
+		retryTopic = true
 	}
 
+	// remove the first response
+	res.Responses = res.Responses[1:]
+	return retryTopic
+}
+
+// handleTokenResponses processes individual token responses and returns tokens that need retry.
+func handleTokenResponses(
+	cfg *config.ConfYaml, req *PushNotification, res *messaging.BatchResponse, resp *ResponsePush,
+) []string {
 	var newTokens []string
 	for k, result := range res.Responses {
 		if result.Error != nil {
@@ -290,16 +247,70 @@ Retry:
 		}
 		logPush(cfg, core.SucceededPush, req.Tokens[k], req, nil)
 	}
+	return newTokens
+}
+
+// logDevMessages logs messages in development mode.
+func logDevMessages(messages []*messaging.Message) {
+	for i, msg := range messages {
+		m, _ := json.Marshal(msg)
+		logx.LogAccess.Infof("message #%d - %s", i, m)
+	}
+}
+
+// PushToAndroid provide send notification to Android server.
+func PushToAndroid(ctx context.Context, req *PushNotification, cfg *config.ConfYaml) (resp *ResponsePush, err error) {
+	logx.LogAccess.Debug("Start push notification for Android")
+
+	if err = CheckMessage(req); err != nil {
+		logx.LogError.Error("request error: " + err.Error())
+		return nil, err
+	}
+
+	client, err := InitFCMClient(ctx, cfg)
+	if err != nil {
+		logx.LogError.Error("FCM server error: " + err.Error())
+		return nil, err
+	}
+
+	maxRetry := cfg.Android.MaxRetry
+	if req.Retry > 0 && req.Retry < maxRetry {
+		maxRetry = req.Retry
+	}
+
+	resp = &ResponsePush{}
+	retryCount := 0
+
+Retry:
+	messages := GetAndroidNotification(req)
+
+	if req.Development {
+		logDevMessages(messages)
+	}
+
+	res, err := client.Send(ctx, messages...)
+	if err != nil {
+		newErr := fmt.Errorf("fcm service send message error: %v", err)
+		logx.LogError.Error(newErr)
+		errLog := logPush(cfg, core.FailedPush, "", req, newErr)
+		resp.Logs = append(resp.Logs, errLog)
+		status.StatStorage.AddAndroidError(1)
+		return resp, newErr
+	}
+
+	logx.LogAccess.Debug(fmt.Sprintf("Android Success count: %d, Failure count: %d", res.SuccessCount, res.FailureCount))
+	status.StatStorage.AddAndroidSuccess(int64(res.SuccessCount))
+	status.StatStorage.AddAndroidError(int64(res.FailureCount))
+
+	retryTopic := handleTopicResponse(cfg, req, res, resp)
+	newTokens := handleTokenResponses(cfg, req, res, resp)
 
 	if len(newTokens) > 0 && retryCount < maxRetry {
 		retryCount++
-
 		if req.IsTopic() && !retryTopic {
 			req.Topic = ""
 			req.Condition = ""
 		}
-
-		// resend fail token
 		req.Tokens = newTokens
 		goto Retry
 	}

--- a/notify/notification_hms.go
+++ b/notify/notification_hms.go
@@ -63,89 +63,87 @@ func InitHMSClient(cfg *config.ConfYaml, appSecret, appID string) (*client.HMSCl
 	return HMSClient, nil
 }
 
+// setHuaweiMessageTarget sets the target (tokens, topic, condition) on the message.
+func setHuaweiMessageTarget(msg *model.Message, req *PushNotification) {
+	if len(req.Tokens) > 0 {
+		msg.Token = req.Tokens
+	}
+	if len(req.Topic) > 0 {
+		msg.Topic = req.Topic
+	}
+	if len(req.Condition) > 0 {
+		msg.Condition = req.Condition
+	}
+}
+
+// setHuaweiAndroidConfig sets Android-specific configuration on the message.
+func setHuaweiAndroidConfig(android *model.AndroidConfig, req *PushNotification) {
+	if req.Priority == HIGH {
+		android.Urgency = "HIGH"
+	}
+	android.CollapseKey = req.HuaweiCollapseKey
+	if len(req.Category) > 0 {
+		android.Category = req.Category
+	}
+	if len(req.HuaweiTTL) > 0 {
+		android.TTL = req.HuaweiTTL
+	}
+	if len(req.BiTag) > 0 {
+		android.BiTag = req.BiTag
+	}
+	android.FastAppTarget = req.FastAppTarget
+}
+
+// setHuaweiNotificationContent sets the notification content fields.
+func setHuaweiNotificationContent(android *model.AndroidConfig, req *PushNotification) {
+	ensureNotification := func() {
+		if android.Notification == nil {
+			android.Notification = model.GetDefaultAndroidNotification()
+		}
+	}
+
+	if len(req.Message) > 0 {
+		ensureNotification()
+		android.Notification.Body = req.Message
+	}
+	if len(req.Title) > 0 {
+		ensureNotification()
+		android.Notification.Title = req.Title
+	}
+	if len(req.Image) > 0 {
+		ensureNotification()
+		android.Notification.Image = req.Image
+	}
+	if v, ok := req.Sound.(string); ok && len(v) > 0 {
+		ensureNotification()
+		android.Notification.Sound = v
+	} else if android.Notification != nil {
+		android.Notification.DefaultSound = true
+	}
+}
+
 // GetHuaweiNotification use for define HMS notification.
 // HTTP Connection Server Reference for HMS
 // https://developer.huawei.com/consumer/en/doc/development/HMS-References/push-sendapi
 func GetHuaweiNotification(req *PushNotification) (*model.MessageRequest, error) {
 	msgRequest := model.NewNotificationMsgRequest()
-
 	msgRequest.Message.Android = model.GetDefaultAndroid()
 
-	if len(req.Tokens) > 0 {
-		msgRequest.Message.Token = req.Tokens
-	}
+	setHuaweiMessageTarget(msgRequest.Message, req)
+	setHuaweiAndroidConfig(msgRequest.Message.Android, req)
 
-	if len(req.Topic) > 0 {
-		msgRequest.Message.Topic = req.Topic
-	}
-
-	if len(req.Condition) > 0 {
-		msgRequest.Message.Condition = req.Condition
-	}
-
-	if req.Priority == HIGH {
-		msgRequest.Message.Android.Urgency = "HIGH"
-	}
-
-	// if req.HuaweiCollapseKey != nil {
-	msgRequest.Message.Android.CollapseKey = req.HuaweiCollapseKey
-	//}
-
-	if len(req.Category) > 0 {
-		msgRequest.Message.Android.Category = req.Category
-	}
-
-	if len(req.HuaweiTTL) > 0 {
-		msgRequest.Message.Android.TTL = req.HuaweiTTL
-	}
-
-	if len(req.BiTag) > 0 {
-		msgRequest.Message.Android.BiTag = req.BiTag
-	}
-
-	msgRequest.Message.Android.FastAppTarget = req.FastAppTarget
-
-	// Add data fields
 	if len(req.HuaweiData) > 0 {
 		msgRequest.Message.Data = req.HuaweiData
 	}
 
-	// Notification Message
 	if req.HuaweiNotification != nil {
 		msgRequest.Message.Android.Notification = req.HuaweiNotification
-
 		if msgRequest.Message.Android.Notification.ClickAction == nil {
 			msgRequest.Message.Android.Notification.ClickAction = model.GetDefaultClickAction()
 		}
 	}
 
-	setDefaultAndroidNotification := func() {
-		if msgRequest.Message.Android.Notification == nil {
-			msgRequest.Message.Android.Notification = model.GetDefaultAndroidNotification()
-		}
-	}
-
-	if len(req.Message) > 0 {
-		setDefaultAndroidNotification()
-		msgRequest.Message.Android.Notification.Body = req.Message
-	}
-
-	if len(req.Title) > 0 {
-		setDefaultAndroidNotification()
-		msgRequest.Message.Android.Notification.Title = req.Title
-	}
-
-	if len(req.Image) > 0 {
-		setDefaultAndroidNotification()
-		msgRequest.Message.Android.Notification.Image = req.Image
-	}
-
-	if v, ok := req.Sound.(string); ok && len(v) > 0 {
-		setDefaultAndroidNotification()
-		msgRequest.Message.Android.Notification.Sound = v
-	} else if msgRequest.Message.Android.Notification != nil {
-		msgRequest.Message.Android.Notification.DefaultSound = true
-	}
+	setHuaweiNotificationContent(msgRequest.Message.Android, req)
 
 	b, err := json.Marshal(msgRequest)
 	if err != nil {

--- a/notify/notification_hms_test.go
+++ b/notify/notification_hms_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/appleboy/gorush/config"
 
+	"github.com/appleboy/go-hms-push/push/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,4 +51,197 @@ func TestMissingAppIDForInitHMSClient(t *testing.T) {
 	assert.Nil(t, client)
 	assert.Error(t, err)
 	assert.Equal(t, "missing huawei app id", err.Error())
+}
+
+// Tests for refactored helper functions
+
+func TestSetHuaweiMessageTarget(t *testing.T) {
+	tests := []struct {
+		name          string
+		req           *PushNotification
+		wantTokens    []string
+		wantTopic     string
+		wantCondition string
+	}{
+		{
+			name: "tokens only",
+			req: &PushNotification{
+				Tokens: []string{"token1", "token2"},
+			},
+			wantTokens: []string{"token1", "token2"},
+		},
+		{
+			name: "topic only",
+			req: &PushNotification{
+				Topic: "test-topic",
+			},
+			wantTopic: "test-topic",
+		},
+		{
+			name: "condition only",
+			req: &PushNotification{
+				Condition: "'dogs' in topics",
+			},
+			wantCondition: "'dogs' in topics",
+		},
+		{
+			name: "all fields",
+			req: &PushNotification{
+				Tokens:    []string{"token1"},
+				Topic:     "topic",
+				Condition: "condition",
+			},
+			wantTokens:    []string{"token1"},
+			wantTopic:     "topic",
+			wantCondition: "condition",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgRequest, err := GetHuaweiNotification(tt.req)
+			assert.NoError(t, err)
+
+			if len(tt.wantTokens) > 0 {
+				assert.Equal(t, tt.wantTokens, msgRequest.Message.Token)
+			}
+			if tt.wantTopic != "" {
+				assert.Equal(t, tt.wantTopic, msgRequest.Message.Topic)
+			}
+			if tt.wantCondition != "" {
+				assert.Equal(t, tt.wantCondition, msgRequest.Message.Condition)
+			}
+		})
+	}
+}
+
+func TestSetHuaweiAndroidConfig(t *testing.T) {
+	collapseKey := 1
+	req := &PushNotification{
+		Tokens:            []string{"token"},
+		Priority:          HIGH,
+		HuaweiCollapseKey: collapseKey,
+		Category:          "test-category",
+		HuaweiTTL:         "86400s",
+		BiTag:             "bi-tag-123",
+		FastAppTarget:     1,
+	}
+
+	msgRequest, err := GetHuaweiNotification(req)
+	assert.NoError(t, err)
+
+	android := msgRequest.Message.Android
+	assert.Equal(t, "HIGH", android.Urgency)
+	assert.Equal(t, collapseKey, android.CollapseKey)
+	assert.Equal(t, "test-category", android.Category)
+	assert.Equal(t, "86400s", android.TTL)
+	assert.Equal(t, "bi-tag-123", android.BiTag)
+	assert.Equal(t, 1, android.FastAppTarget)
+}
+
+func TestSetHuaweiNotificationContent(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       *PushNotification
+		wantTitle string
+		wantBody  string
+		wantImage string
+		wantSound string
+	}{
+		{
+			name: "title and message",
+			req: &PushNotification{
+				Tokens:  []string{"token"},
+				Title:   "Test Title",
+				Message: "Test Message",
+			},
+			wantTitle: "Test Title",
+			wantBody:  "Test Message",
+		},
+		{
+			name: "image",
+			req: &PushNotification{
+				Tokens: []string{"token"},
+				Image:  "https://example.com/image.png",
+			},
+			wantImage: "https://example.com/image.png",
+		},
+		{
+			name: "custom sound",
+			req: &PushNotification{
+				Tokens: []string{"token"},
+				Sound:  "custom.mp3",
+			},
+			wantSound: "custom.mp3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgRequest, err := GetHuaweiNotification(tt.req)
+			assert.NoError(t, err)
+
+			notification := msgRequest.Message.Android.Notification
+			if tt.wantTitle != "" {
+				assert.Equal(t, tt.wantTitle, notification.Title)
+			}
+			if tt.wantBody != "" {
+				assert.Equal(t, tt.wantBody, notification.Body)
+			}
+			if tt.wantImage != "" {
+				assert.Equal(t, tt.wantImage, notification.Image)
+			}
+			if tt.wantSound != "" {
+				assert.Equal(t, tt.wantSound, notification.Sound)
+			}
+		})
+	}
+}
+
+func TestHuaweiNotificationDefaultSound(t *testing.T) {
+	req := &PushNotification{
+		Tokens:  []string{"token"},
+		Title:   "Title",
+		Message: "Message",
+		// No sound specified
+	}
+
+	msgRequest, err := GetHuaweiNotification(req)
+	assert.NoError(t, err)
+
+	notification := msgRequest.Message.Android.Notification
+	assert.True(t, notification.DefaultSound)
+}
+
+func TestHuaweiNotificationWithData(t *testing.T) {
+	req := &PushNotification{
+		Tokens:     []string{"token"},
+		HuaweiData: `{"key":"value"}`,
+	}
+
+	msgRequest, err := GetHuaweiNotification(req)
+	assert.NoError(t, err)
+
+	assert.Equal(t, `{"key":"value"}`, msgRequest.Message.Data)
+}
+
+func TestHuaweiNotificationWithCustomNotification(t *testing.T) {
+	req := &PushNotification{
+		Tokens: []string{"token"},
+		HuaweiNotification: &model.AndroidNotification{
+			Title: "Custom Title",
+			Body:  "Custom Body",
+			Image: "custom-image.png",
+		},
+	}
+
+	msgRequest, err := GetHuaweiNotification(req)
+	assert.NoError(t, err)
+
+	notification := msgRequest.Message.Android.Notification
+	assert.Equal(t, "Custom Title", notification.Title)
+	assert.Equal(t, "Custom Body", notification.Body)
+	assert.Equal(t, "custom-image.png", notification.Image)
+	// ClickAction should be set to default
+	assert.NotNil(t, notification.ClickAction)
 }

--- a/notify/notification_test.go
+++ b/notify/notification_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	testHuaweiAppID     = "app-id"
+	testHuaweiAppSecret = "app-secret"
+)
+
 func TestCorrectConf(t *testing.T) {
 	cfg, _ := config.LoadConf()
 
@@ -31,5 +36,131 @@ func TestSetProxyURL(t *testing.T) {
 	assert.Error(t, err)
 
 	err = SetProxy("http://87.236.233.92:8080")
+	assert.NoError(t, err)
+}
+
+// Tests for refactored helper functions
+
+func TestCheckIOSConf(t *testing.T) {
+	cfg, _ := config.LoadConf()
+
+	// iOS disabled - should pass
+	cfg.Ios.Enabled = false
+	err := checkIOSConf(cfg)
+	assert.NoError(t, err)
+
+	// iOS enabled but missing key path and base64
+	cfg.Ios.Enabled = true
+	cfg.Ios.KeyPath = ""
+	cfg.Ios.KeyBase64 = ""
+	err = checkIOSConf(cfg)
+	assert.Error(t, err)
+	assert.Equal(t, "missing iOS certificate key", err.Error())
+
+	// iOS enabled with valid key path
+	cfg.Ios.KeyPath = testKeyPath
+	err = checkIOSConf(cfg)
+	assert.NoError(t, err)
+
+	// iOS enabled with key base64 (no key path)
+	cfg.Ios.KeyPath = ""
+	cfg.Ios.KeyBase64 = "some-base64-data"
+	err = checkIOSConf(cfg)
+	assert.NoError(t, err)
+
+	// iOS enabled with non-existent file
+	cfg.Ios.KeyPath = "non-existent-file.pem"
+	cfg.Ios.KeyBase64 = ""
+	err = checkIOSConf(cfg)
+	assert.Error(t, err)
+	assert.Equal(t, "certificate file does not exist", err.Error())
+}
+
+func TestCheckAndroidConf(t *testing.T) {
+	cfg, _ := config.LoadConf()
+
+	// Android disabled - should pass
+	cfg.Android.Enabled = false
+	err := checkAndroidConf(cfg)
+	assert.NoError(t, err)
+
+	// Android enabled but no credentials
+	cfg.Android.Enabled = true
+	cfg.Android.Credential = ""
+	cfg.Android.KeyPath = ""
+	// Clear environment variable for this test
+	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+	err = checkAndroidConf(cfg)
+	assert.Error(t, err)
+	assert.Equal(t, "missing fcm credential data", err.Error())
+
+	// Android enabled with credential
+	cfg.Android.Credential = "some-credential"
+	err = checkAndroidConf(cfg)
+	assert.NoError(t, err)
+
+	// Android enabled with key path
+	cfg.Android.Credential = ""
+	cfg.Android.KeyPath = "/path/to/key.json"
+	err = checkAndroidConf(cfg)
+	assert.NoError(t, err)
+}
+
+func TestCheckHuaweiConf(t *testing.T) {
+	cfg, _ := config.LoadConf()
+
+	// Huawei disabled - should pass
+	cfg.Huawei.Enabled = false
+	err := checkHuaweiConf(cfg)
+	assert.NoError(t, err)
+
+	// Huawei enabled but missing app secret
+	cfg.Huawei.Enabled = true
+	cfg.Huawei.AppSecret = ""
+	cfg.Huawei.AppID = testHuaweiAppID
+	err = checkHuaweiConf(cfg)
+	assert.Error(t, err)
+	assert.Equal(t, "missing huawei app secret", err.Error())
+
+	// Huawei enabled but missing app id
+	cfg.Huawei.AppSecret = testHuaweiAppSecret
+	cfg.Huawei.AppID = ""
+	err = checkHuaweiConf(cfg)
+	assert.Error(t, err)
+	assert.Equal(t, "missing huawei app id", err.Error())
+
+	// Huawei enabled with all credentials
+	cfg.Huawei.AppSecret = testHuaweiAppSecret
+	cfg.Huawei.AppID = testHuaweiAppID
+	err = checkHuaweiConf(cfg)
+	assert.NoError(t, err)
+}
+
+func TestCheckPushConfNoPlatformEnabled(t *testing.T) {
+	cfg, _ := config.LoadConf()
+
+	cfg.Ios.Enabled = false
+	cfg.Android.Enabled = false
+	cfg.Huawei.Enabled = false
+
+	err := CheckPushConf(cfg)
+	assert.Error(t, err)
+	assert.Equal(t, "please enable iOS, Android or Huawei config in yml config", err.Error())
+}
+
+func TestCheckPushConfAllPlatformsValid(t *testing.T) {
+	cfg, _ := config.LoadConf()
+
+	cfg.Ios.Enabled = true
+	cfg.Ios.KeyPath = testKeyPath
+
+	cfg.Android.Enabled = true
+	cfg.Android.Credential = "some-credential"
+
+	cfg.Huawei.Enabled = true
+	cfg.Huawei.AppSecret = testHuaweiAppSecret
+	cfg.Huawei.AppID = testHuaweiAppID
+
+	err := CheckPushConf(cfg)
 	assert.NoError(t, err)
 }

--- a/router/server.go
+++ b/router/server.go
@@ -246,6 +246,42 @@ func markFailedNotification(
 	return logs
 }
 
+// isPlatformEnabled checks if the notification platform is enabled in config.
+func isPlatformEnabled(cfg *config.ConfYaml, platform int) bool {
+	switch platform {
+	case core.PlatFormIos:
+		return cfg.Ios.Enabled
+	case core.PlatFormAndroid:
+		return cfg.Android.Enabled
+	case core.PlatFormHuawei:
+		return cfg.Huawei.Enabled
+	default:
+		return false
+	}
+}
+
+// filterEnabledNotifications filters notifications to only those with enabled platforms.
+func filterEnabledNotifications(
+	cfg *config.ConfYaml, notifications []notify.PushNotification,
+) []*notify.PushNotification {
+	result := make([]*notify.PushNotification, 0, len(notifications))
+	for i := range notifications {
+		if isPlatformEnabled(cfg, notifications[i].Platform) {
+			result = append(result, &notifications[i])
+		}
+	}
+	return result
+}
+
+// countNotificationTargets counts the total number of targets (tokens + topics) in a notification.
+func countNotificationTargets(notification *notify.PushNotification) int {
+	count := len(notification.Tokens)
+	if notification.Topic != "" {
+		count++
+	}
+	return count
+}
+
 // HandleNotification add notification to queue list.
 func handleNotification(
 	_ context.Context,
@@ -253,40 +289,25 @@ func handleNotification(
 	req notify.RequestPush,
 	q *queue.Queue,
 ) (int, []logx.LogPushEntry) {
-	var count int
-	wg := sync.WaitGroup{}
-	newNotification := []*notify.PushNotification{}
-
 	if cfg.Core.Sync && !core.IsLocalQueue(core.Queue(cfg.Queue.Engine)) {
 		cfg.Core.Sync = false
 	}
 
-	for i := range req.Notifications {
-		notification := &req.Notifications[i]
-		switch notification.Platform {
-		case core.PlatFormIos:
-			if !cfg.Ios.Enabled {
-				continue
-			}
-		case core.PlatFormAndroid:
-			if !cfg.Android.Enabled {
-				continue
-			}
-		case core.PlatFormHuawei:
-			if !cfg.Huawei.Enabled {
-				continue
-			}
-		}
-		newNotification = append(newNotification, notification)
-	}
+	notifications := filterEnabledNotifications(cfg, req.Notifications)
+	isLocalSync := core.IsLocalQueue(core.Queue(cfg.Queue.Engine)) && cfg.Core.Sync
 
-	logs := make([]logx.LogPushEntry, 0, count)
-	for _, notification := range newNotification {
+	var (
+		count int
+		wg    sync.WaitGroup
+		logs  = make([]logx.LogPushEntry, 0)
+	)
+
+	for _, notification := range notifications {
 		if cfg.Core.Sync {
 			wg.Add(1)
 		}
 
-		if core.IsLocalQueue(core.Queue(cfg.Queue.Engine)) && cfg.Core.Sync {
+		if isLocalSync {
 			func(msg *notify.PushNotification, cfg *config.ConfYaml) {
 				if err := q.QueueTask(func(ctx context.Context) error {
 					defer wg.Done()
@@ -294,10 +315,7 @@ func handleNotification(
 					if err != nil {
 						return err
 					}
-
-					// add log
 					logs = append(logs, resp.Logs...)
-
 					return nil
 				}); err != nil {
 					logx.LogError.Error(err)
@@ -305,16 +323,11 @@ func handleNotification(
 			}(notification, cfg)
 		} else if err := q.Queue(notification); err != nil {
 			resp := markFailedNotification(cfg, notification, "max capacity reached")
-			// add log
 			logs = append(logs, resp...)
 			wg.Done()
 		}
 
-		count += len(notification.Tokens)
-		// Count topic message
-		if notification.Topic != "" {
-			count++
-		}
+		count += countNotificationTargets(notification)
 	}
 
 	if cfg.Core.Sync {

--- a/router/server_test.go
+++ b/router/server_test.go
@@ -687,3 +687,151 @@ func TestDisabledIosNotifications(t *testing.T) {
 	assert.Equal(t, 2, count)
 	assert.Equal(t, 0, len(logs))
 }
+
+// Tests for refactored helper functions
+
+func TestIsPlatformEnabled(t *testing.T) {
+	cfg := initTest()
+
+	tests := []struct {
+		name           string
+		platform       int
+		iosEnabled     bool
+		androidEnabled bool
+		huaweiEnabled  bool
+		want           bool
+	}{
+		{
+			name:       "iOS enabled",
+			platform:   core.PlatFormIos,
+			iosEnabled: true,
+			want:       true,
+		},
+		{
+			name:       "iOS disabled",
+			platform:   core.PlatFormIos,
+			iosEnabled: false,
+			want:       false,
+		},
+		{
+			name:           "Android enabled",
+			platform:       core.PlatFormAndroid,
+			androidEnabled: true,
+			want:           true,
+		},
+		{
+			name:           "Android disabled",
+			platform:       core.PlatFormAndroid,
+			androidEnabled: false,
+			want:           false,
+		},
+		{
+			name:          "Huawei enabled",
+			platform:      core.PlatFormHuawei,
+			huaweiEnabled: true,
+			want:          true,
+		},
+		{
+			name:          "Huawei disabled",
+			platform:      core.PlatFormHuawei,
+			huaweiEnabled: false,
+			want:          false,
+		},
+		{
+			name:     "Unknown platform",
+			platform: 99,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg.Ios.Enabled = tt.iosEnabled
+			cfg.Android.Enabled = tt.androidEnabled
+			cfg.Huawei.Enabled = tt.huaweiEnabled
+
+			got := isPlatformEnabled(cfg, tt.platform)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFilterEnabledNotifications(t *testing.T) {
+	cfg := initTest()
+	cfg.Ios.Enabled = true
+	cfg.Android.Enabled = true
+	cfg.Huawei.Enabled = false
+
+	notifications := []notify.PushNotification{
+		{Platform: core.PlatFormIos, Message: "iOS message"},
+		{Platform: core.PlatFormAndroid, Message: "Android message"},
+		{Platform: core.PlatFormHuawei, Message: "Huawei message"},
+		{Platform: core.PlatFormIos, Message: "iOS message 2"},
+	}
+
+	result := filterEnabledNotifications(cfg, notifications)
+
+	assert.Len(t, result, 3)
+	assert.Equal(t, "iOS message", result[0].Message)
+	assert.Equal(t, "Android message", result[1].Message)
+	assert.Equal(t, "iOS message 2", result[2].Message)
+}
+
+func TestFilterEnabledNotificationsAllDisabled(t *testing.T) {
+	cfg := initTest()
+	cfg.Ios.Enabled = false
+	cfg.Android.Enabled = false
+	cfg.Huawei.Enabled = false
+
+	notifications := []notify.PushNotification{
+		{Platform: core.PlatFormIos, Message: "iOS message"},
+		{Platform: core.PlatFormAndroid, Message: "Android message"},
+	}
+
+	result := filterEnabledNotifications(cfg, notifications)
+
+	assert.Len(t, result, 0)
+}
+
+func TestCountNotificationTargets(t *testing.T) {
+	tests := []struct {
+		name         string
+		notification *notify.PushNotification
+		want         int
+	}{
+		{
+			name: "tokens only",
+			notification: &notify.PushNotification{
+				Tokens: []string{"token1", "token2", "token3"},
+			},
+			want: 3,
+		},
+		{
+			name: "topic only",
+			notification: &notify.PushNotification{
+				Topic: "test-topic",
+			},
+			want: 1,
+		},
+		{
+			name: "tokens and topic",
+			notification: &notify.PushNotification{
+				Tokens: []string{"token1", "token2"},
+				Topic:  "test-topic",
+			},
+			want: 3,
+		},
+		{
+			name:         "empty notification",
+			notification: &notify.PushNotification{},
+			want:         0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countNotificationTargets(tt.notification)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
- Refactor configuration checks for iOS, Android, and Huawei platforms into separate validation functions
- Modularize APNS client initialization and payload construction with new helper functions for certificate/key loading and notification attribute setup
- Break notification payload generation into smaller, composable functions for improved clarity and testability
- Split FCM notification construction and payload formatting into dedicated helper functions
- Separate Huawei notification building into specific helper functions for message targets, Android config, and notification content
- Add extensive unit tests for new helper functions and refactored logic across iOS, Android/FCM, and Huawei notification handling
- Implement filtering and counting utilities for notification targets in the queue server logic
- Enhance code readability, maintainability, and test coverage throughout the notification module