### PR TITLE
fix(config): redact sensitive fields in /api/config response

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -624,3 +624,44 @@ func ValidateConfig(cfg *ConfYaml) error {
 
 	return nil
 }
+
+// SanitizedCopy returns a copy of the config with sensitive fields redacted.
+func (c *ConfYaml) SanitizedCopy() *ConfYaml {
+	sanitized := *c
+
+	// Core TLS & proxy
+	sanitized.Core.CertBase64 = redact(c.Core.CertBase64)
+	sanitized.Core.KeyBase64 = redact(c.Core.KeyBase64)
+	sanitized.Core.HTTPProxy = redact(c.Core.HTTPProxy)
+
+	// Android
+	sanitized.Android.KeyPath = redact(c.Android.KeyPath)
+	sanitized.Android.Credential = redact(c.Android.Credential)
+
+	// Huawei
+	sanitized.Huawei.AppSecret = redact(c.Huawei.AppSecret)
+
+	// iOS
+	sanitized.Ios.KeyPath = redact(c.Ios.KeyPath)
+	sanitized.Ios.KeyBase64 = redact(c.Ios.KeyBase64)
+	sanitized.Ios.Password = redact(c.Ios.Password)
+	sanitized.Ios.KeyID = redact(c.Ios.KeyID)
+	sanitized.Ios.TeamID = redact(c.Ios.TeamID)
+
+	// Queue Redis
+	sanitized.Queue.Redis.Username = redact(c.Queue.Redis.Username)
+	sanitized.Queue.Redis.Password = redact(c.Queue.Redis.Password)
+
+	// Stat Redis
+	sanitized.Stat.Redis.Username = redact(c.Stat.Redis.Username)
+	sanitized.Stat.Redis.Password = redact(c.Stat.Redis.Password)
+
+	return &sanitized
+}
+
+func redact(s string) string {
+	if s != "" {
+		return "[REDACTED]"
+	}
+	return ""
+}

--- a/config/config.go
+++ b/config/config.go
@@ -633,6 +633,16 @@ func (c *ConfYaml) SanitizedCopy() *ConfYaml {
 	sanitized.Core.CertBase64 = redact(c.Core.CertBase64)
 	sanitized.Core.KeyBase64 = redact(c.Core.KeyBase64)
 	sanitized.Core.HTTPProxy = redact(c.Core.HTTPProxy)
+	sanitized.Core.CertPath = redact(c.Core.CertPath)
+	sanitized.Core.KeyPath = redact(c.Core.KeyPath)
+	if len(c.Core.FeedbackHeader) > 0 {
+		sanitized.Core.FeedbackHeader = make([]string, len(c.Core.FeedbackHeader))
+		for i, v := range c.Core.FeedbackHeader {
+			if v != "" {
+				sanitized.Core.FeedbackHeader[i] = "[REDACTED]"
+			}
+		}
+	}
 
 	// Android
 	sanitized.Android.KeyPath = redact(c.Android.KeyPath)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -782,6 +782,9 @@ func TestSanitizedCopy(t *testing.T) {
 	cfg.Core.CertBase64 = "cert-data"
 	cfg.Core.KeyBase64 = "key-data"
 	cfg.Core.HTTPProxy = "http://proxy:8080"
+	cfg.Core.CertPath = "/path/to/cert.pem"
+	cfg.Core.KeyPath = "/path/to/key.pem"
+	cfg.Core.FeedbackHeader = []string{"x-api-key:secret123", "x-auth-key:secret456"}
 	cfg.Android.KeyPath = "/path/to/key.json"
 	cfg.Android.Credential = "fcm-credential"
 	cfg.Huawei.AppSecret = "hms-secret"
@@ -804,6 +807,11 @@ func TestSanitizedCopy(t *testing.T) {
 	assert.Equal(t, "[REDACTED]", sanitized.Core.CertBase64)
 	assert.Equal(t, "[REDACTED]", sanitized.Core.KeyBase64)
 	assert.Equal(t, "[REDACTED]", sanitized.Core.HTTPProxy)
+	assert.Equal(t, "[REDACTED]", sanitized.Core.CertPath)
+	assert.Equal(t, "[REDACTED]", sanitized.Core.KeyPath)
+	assert.Len(t, sanitized.Core.FeedbackHeader, 2)
+	assert.Equal(t, "[REDACTED]", sanitized.Core.FeedbackHeader[0])
+	assert.Equal(t, "[REDACTED]", sanitized.Core.FeedbackHeader[1])
 	assert.Equal(t, "[REDACTED]", sanitized.Android.KeyPath)
 	assert.Equal(t, "[REDACTED]", sanitized.Android.Credential)
 	assert.Equal(t, "[REDACTED]", sanitized.Huawei.AppSecret)
@@ -821,6 +829,9 @@ func TestSanitizedCopy(t *testing.T) {
 	assert.Equal(t, "8088", sanitized.Core.Port)
 
 	// Original config must NOT be modified
+	assert.Equal(t, "/path/to/cert.pem", cfg.Core.CertPath)
+	assert.Equal(t, "/path/to/key.pem", cfg.Core.KeyPath)
+	assert.Equal(t, "x-api-key:secret123", cfg.Core.FeedbackHeader[0])
 	assert.Equal(t, "cert-data", cfg.Core.CertBase64)
 	assert.Equal(t, "fcm-credential", cfg.Android.Credential)
 	assert.Equal(t, "ios-password", cfg.Ios.Password)
@@ -837,6 +848,9 @@ func TestSanitizedCopyEmptyFields(t *testing.T) {
 	assert.Empty(t, sanitized.Core.CertBase64)
 	assert.Empty(t, sanitized.Core.KeyBase64)
 	assert.Empty(t, sanitized.Core.HTTPProxy)
+	assert.Empty(t, sanitized.Core.CertPath)
+	assert.Empty(t, sanitized.Core.KeyPath)
+	assert.Nil(t, sanitized.Core.FeedbackHeader)
 	assert.Empty(t, sanitized.Android.KeyPath)
 	assert.Empty(t, sanitized.Android.Credential)
 	assert.Empty(t, sanitized.Huawei.AppSecret)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -776,3 +776,77 @@ func TestAllAPIEndpointsHaveDefaults(t *testing.T) {
 	assert.Equal(t, "/metrics", conf.API.MetricURI)
 	assert.Equal(t, "/healthz", conf.API.HealthURI)
 }
+
+func TestSanitizedCopy(t *testing.T) {
+	cfg := &ConfYaml{}
+	cfg.Core.CertBase64 = "cert-data"
+	cfg.Core.KeyBase64 = "key-data"
+	cfg.Core.HTTPProxy = "http://proxy:8080"
+	cfg.Android.KeyPath = "/path/to/key.json"
+	cfg.Android.Credential = "fcm-credential"
+	cfg.Huawei.AppSecret = "hms-secret"
+	cfg.Ios.KeyPath = "/path/to/ios.p8"
+	cfg.Ios.KeyBase64 = "ios-key-data"
+	cfg.Ios.Password = "ios-password"
+	cfg.Ios.KeyID = "ABCDE12345"
+	cfg.Ios.TeamID = "TEAM123456"
+	cfg.Queue.Redis.Username = "queue-user"
+	cfg.Queue.Redis.Password = "queue-pass"
+	cfg.Stat.Redis.Username = "stat-user"
+	cfg.Stat.Redis.Password = "stat-pass"
+
+	// Set a non-sensitive field to verify it's preserved
+	cfg.Core.Port = "8088"
+
+	sanitized := cfg.SanitizedCopy()
+
+	// All sensitive fields should be redacted
+	assert.Equal(t, "[REDACTED]", sanitized.Core.CertBase64)
+	assert.Equal(t, "[REDACTED]", sanitized.Core.KeyBase64)
+	assert.Equal(t, "[REDACTED]", sanitized.Core.HTTPProxy)
+	assert.Equal(t, "[REDACTED]", sanitized.Android.KeyPath)
+	assert.Equal(t, "[REDACTED]", sanitized.Android.Credential)
+	assert.Equal(t, "[REDACTED]", sanitized.Huawei.AppSecret)
+	assert.Equal(t, "[REDACTED]", sanitized.Ios.KeyPath)
+	assert.Equal(t, "[REDACTED]", sanitized.Ios.KeyBase64)
+	assert.Equal(t, "[REDACTED]", sanitized.Ios.Password)
+	assert.Equal(t, "[REDACTED]", sanitized.Ios.KeyID)
+	assert.Equal(t, "[REDACTED]", sanitized.Ios.TeamID)
+	assert.Equal(t, "[REDACTED]", sanitized.Queue.Redis.Username)
+	assert.Equal(t, "[REDACTED]", sanitized.Queue.Redis.Password)
+	assert.Equal(t, "[REDACTED]", sanitized.Stat.Redis.Username)
+	assert.Equal(t, "[REDACTED]", sanitized.Stat.Redis.Password)
+
+	// Non-sensitive fields should be preserved
+	assert.Equal(t, "8088", sanitized.Core.Port)
+
+	// Original config must NOT be modified
+	assert.Equal(t, "cert-data", cfg.Core.CertBase64)
+	assert.Equal(t, "fcm-credential", cfg.Android.Credential)
+	assert.Equal(t, "ios-password", cfg.Ios.Password)
+	assert.Equal(t, "stat-pass", cfg.Stat.Redis.Password)
+}
+
+func TestSanitizedCopyEmptyFields(t *testing.T) {
+	cfg := &ConfYaml{}
+	// All sensitive fields are empty by default
+
+	sanitized := cfg.SanitizedCopy()
+
+	// Empty fields should remain empty, not become "[REDACTED]"
+	assert.Empty(t, sanitized.Core.CertBase64)
+	assert.Empty(t, sanitized.Core.KeyBase64)
+	assert.Empty(t, sanitized.Core.HTTPProxy)
+	assert.Empty(t, sanitized.Android.KeyPath)
+	assert.Empty(t, sanitized.Android.Credential)
+	assert.Empty(t, sanitized.Huawei.AppSecret)
+	assert.Empty(t, sanitized.Ios.KeyPath)
+	assert.Empty(t, sanitized.Ios.KeyBase64)
+	assert.Empty(t, sanitized.Ios.Password)
+	assert.Empty(t, sanitized.Ios.KeyID)
+	assert.Empty(t, sanitized.Ios.TeamID)
+	assert.Empty(t, sanitized.Queue.Redis.Username)
+	assert.Empty(t, sanitized.Queue.Redis.Password)
+	assert.Empty(t, sanitized.Stat.Redis.Username)
+	assert.Empty(t, sanitized.Stat.Redis.Password)
+}

--- a/router/server.go
+++ b/router/server.go
@@ -112,7 +112,7 @@ func pushHandler(cfg *config.ConfYaml, q *queue.Queue) gin.HandlerFunc {
 
 func configHandler(cfg *config.ConfYaml) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.YAML(http.StatusCreated, cfg)
+		c.YAML(http.StatusOK, cfg.SanitizedCopy())
 	}
 }
 

--- a/router/server_test.go
+++ b/router/server_test.go
@@ -281,11 +281,22 @@ func TestAPIStatusAppHandler(t *testing.T) {
 func TestAPIConfigHandler(t *testing.T) {
 	cfg := initTest()
 
+	// Set sensitive values to verify they are redacted
+	cfg.Android.Credential = "secret-fcm-credential"
+	cfg.Ios.Password = "secret-ios-password"
+	cfg.Stat.Redis.Password = "secret-redis-password"
+
 	r := gofight.New()
 
 	r.GET("/api/config").
 		Run(routerEngine(cfg, q), func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
-			assert.Equal(t, http.StatusCreated, r.Code)
+			assert.Equal(t, http.StatusOK, r.Code)
+
+			body := r.Body.String()
+			assert.NotContains(t, body, "secret-fcm-credential")
+			assert.NotContains(t, body, "secret-ios-password")
+			assert.NotContains(t, body, "secret-redis-password")
+			assert.Contains(t, body, "[REDACTED]")
 		})
 }
 


### PR DESCRIPTION
## Summary
- Add `SanitizedCopy()` method on `ConfYaml` to return a copy with all sensitive fields (credentials, passwords, TLS keys, proxy URLs) replaced with `[REDACTED]`
- Update `configHandler` to use `cfg.SanitizedCopy()` instead of exposing the raw config struct
- Fix incorrect HTTP status from `201 Created` to `200 OK` for the GET endpoint

## Redacted Fields
| Struct | Fields | Reason |
|--------|--------|--------|
| Core | CertBase64, KeyBase64 | TLS private key/cert |
| Core | HTTPProxy | May contain auth credentials |
| Android | KeyPath, Credential | FCM credentials |
| Huawei | AppSecret | HMS secret |
| iOS | KeyPath, KeyBase64, Password, KeyID, TeamID | APNS credentials |
| Queue.Redis | Username, Password | Redis auth |
| Stat.Redis | Username, Password | Redis auth |

## Test plan
- [x] `TestSanitizedCopy` — verifies all sensitive fields are redacted, non-sensitive fields preserved, original config unmodified
- [x] `TestSanitizedCopyEmptyFields` — verifies empty strings stay empty (not `[REDACTED]`)
- [x] `TestAPIConfigHandler` — verifies response uses HTTP 200, contains `[REDACTED]`, and does not contain raw secret values
- [x] Linter passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)