### PR TITLE
fix(router): propagate HTTP request context into push notification tasks

### DIFF
--- a/router/server.go
+++ b/router/server.go
@@ -313,6 +313,7 @@ func handleNotification(
 	var (
 		count int
 		wg    sync.WaitGroup
+		mu    sync.Mutex
 		logs  = make([]logx.LogPushEntry, 0)
 	)
 
@@ -335,9 +336,14 @@ func handleNotification(
 					if err != nil {
 						return err
 					}
+					mu.Lock()
 					logs = append(logs, resp.Logs...)
+					mu.Unlock()
 					return nil
 				}); err != nil {
+					if cfg.Core.Sync {
+						wg.Done()
+					}
 					logx.LogError.Error(err)
 				}
 			}(notification, cfg, ctx)

--- a/router/server.go
+++ b/router/server.go
@@ -280,7 +280,6 @@ func countNotificationTargets(notification *notify.PushNotification) int {
 	return count
 }
 
-
 // withEitherCancel returns a context that is cancelled when either ctx1 or ctx2 is done.
 // This is useful for merging an HTTP request context with a queue-task context so that
 // a push notification is aborted when the caller disconnects OR when the queue shuts down.

--- a/router/server.go
+++ b/router/server.go
@@ -280,9 +280,25 @@ func countNotificationTargets(notification *notify.PushNotification) int {
 	return count
 }
 
+
+// withEitherCancel returns a context that is cancelled when either ctx1 or ctx2 is done.
+// This is useful for merging an HTTP request context with a queue-task context so that
+// a push notification is aborted when the caller disconnects OR when the queue shuts down.
+func withEitherCancel(ctx1, ctx2 context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(ctx1)
+	go func() {
+		select {
+		case <-ctx2.Done():
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
+}
+
 // HandleNotification add notification to queue list.
 func handleNotification(
-	_ context.Context,
+	ctx context.Context,
 	cfg *config.ConfYaml,
 	req notify.RequestPush,
 	q *queue.Queue,
@@ -306,10 +322,16 @@ func handleNotification(
 		}
 
 		if isLocalSync {
-			func(msg *notify.PushNotification, cfg *config.ConfYaml) {
-				if err := q.QueueTask(func(ctx context.Context) error {
+			func(msg *notify.PushNotification, cfg *config.ConfYaml, reqCtx context.Context) {
+				if err := q.QueueTask(func(queueCtx context.Context) error {
 					defer wg.Done()
-					resp, err := notify.SendNotification(ctx, msg, cfg)
+					// Merge the HTTP request context with the queue context so that
+					// the notification is cancelled when either the client disconnects
+					// or the queue shuts down. See:
+					// https://github.com/appleboy/gorush/issues/422
+					mergedCtx, cancel := withEitherCancel(reqCtx, queueCtx)
+					defer cancel()
+					resp, err := notify.SendNotification(mergedCtx, msg, cfg)
 					if err != nil {
 						return err
 					}
@@ -318,7 +340,7 @@ func handleNotification(
 				}); err != nil {
 					logx.LogError.Error(err)
 				}
-			}(notification, cfg)
+			}(notification, cfg, ctx)
 		} else if err := q.Queue(notification); err != nil {
 			resp := markFailedNotification(cfg, notification, "max capacity reached")
 			logs = append(logs, resp...)

--- a/router/server_test.go
+++ b/router/server_test.go
@@ -853,3 +853,170 @@ func TestCountNotificationTargets(t *testing.T) {
 		})
 	}
 }
+
+// TestWithEitherCancel_Ctx1Cancel verifies that the derived context is cancelled
+// when ctx1 (the first parent, e.g. the HTTP request context) is cancelled.
+func TestWithEitherCancel_Ctx1Cancel(t *testing.T) {
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	merged, cancelMerged := withEitherCancel(ctx1, ctx2)
+	defer cancelMerged()
+
+	// ctx1 has not been cancelled yet - merged should be alive
+	select {
+	case <-merged.Done():
+		t.Fatal("merged context should not be done yet")
+	default:
+	}
+
+	// Cancel ctx1 (simulates HTTP client disconnect)
+	cancel1()
+
+	select {
+	case <-merged.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("merged context should have been cancelled when ctx1 was cancelled")
+	}
+}
+
+// TestWithEitherCancel_Ctx2Cancel verifies that the derived context is cancelled
+// when ctx2 (the second parent, e.g. the queue-task context) is cancelled.
+func TestWithEitherCancel_Ctx2Cancel(t *testing.T) {
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel1()
+
+	merged, cancelMerged := withEitherCancel(ctx1, ctx2)
+	defer cancelMerged()
+
+	// Neither parent cancelled yet - merged should be alive
+	select {
+	case <-merged.Done():
+		t.Fatal("merged context should not be done yet")
+	default:
+	}
+
+	// Cancel ctx2 (simulates queue shutdown)
+	cancel2()
+
+	select {
+	case <-merged.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("merged context should have been cancelled when ctx2 was cancelled")
+	}
+}
+
+// TestWithEitherCancel_ExplicitCancel verifies that calling the returned
+// CancelFunc directly cancels the merged context without affecting either parent.
+func TestWithEitherCancel_ExplicitCancel(t *testing.T) {
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel1()
+	defer cancel2()
+
+	merged, cancelMerged := withEitherCancel(ctx1, ctx2)
+
+	// Explicitly cancel the merged context
+	cancelMerged()
+
+	select {
+	case <-merged.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("merged context should have been cancelled by explicit cancelMerged()")
+	}
+
+	// Parents should still be alive
+	select {
+	case <-ctx1.Done():
+		t.Fatal("ctx1 should not be cancelled")
+	default:
+	}
+	select {
+	case <-ctx2.Done():
+		t.Fatal("ctx2 should not be cancelled")
+	default:
+	}
+}
+
+// TestWithEitherCancel_NoGoroutineLeak verifies that the internal goroutine
+// spawned by withEitherCancel exits when the merged context is cancelled,
+// preventing goroutine leaks.
+func TestWithEitherCancel_NoGoroutineLeak(t *testing.T) {
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	goroutinesBefore := runtime.NumGoroutine()
+
+	merged, cancelMerged := withEitherCancel(ctx1, ctx2)
+
+	// Give the internal goroutine time to start
+	time.Sleep(10 * time.Millisecond)
+	goroutinesDuring := runtime.NumGoroutine()
+	assert.GreaterOrEqual(t, goroutinesDuring, goroutinesBefore,
+		"at least one new goroutine should exist while merged context is live")
+
+	// Cancel via ctx1 - this should trigger the internal goroutine to exit
+	cancel1()
+	cancelMerged() // also call cancelMerged to release resources
+
+	// Give the goroutine time to clean up
+	time.Sleep(50 * time.Millisecond)
+	goroutinesAfter := runtime.NumGoroutine()
+
+	assert.LessOrEqual(t, goroutinesAfter, goroutinesBefore+1,
+		"goroutine count should return to baseline after cancellation (allow ±1 for runtime variance)")
+
+	// merged context must be done
+	select {
+	case <-merged.Done():
+		// expected
+	default:
+		t.Fatal("merged context should be done after cancel1() and cancelMerged()")
+	}
+}
+
+// TestWithEitherCancel_AlreadyCancelledCtx1 verifies that if ctx1 is already
+// cancelled before withEitherCancel is called, the merged context is immediately done.
+func TestWithEitherCancel_AlreadyCancelledCtx1(t *testing.T) {
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	cancel1() // already cancelled
+
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	merged, cancelMerged := withEitherCancel(ctx1, ctx2)
+	defer cancelMerged()
+
+	select {
+	case <-merged.Done():
+		// expected - ctx1 was already done, so merged should be immediately done
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("merged context should be immediately done when ctx1 is already cancelled")
+	}
+}
+
+// TestWithEitherCancel_AlreadyCancelledCtx2 verifies that if ctx2 is already
+// cancelled before withEitherCancel is called, the merged context is cancelled promptly.
+func TestWithEitherCancel_AlreadyCancelledCtx2(t *testing.T) {
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	cancel2() // already cancelled
+
+	merged, cancelMerged := withEitherCancel(ctx1, ctx2)
+	defer cancelMerged()
+
+	select {
+	case <-merged.Done():
+		// expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("merged context should be cancelled promptly when ctx2 is already cancelled")
+	}
+}

--- a/router/server_test.go
+++ b/router/server_test.go
@@ -858,8 +858,7 @@ func TestCountNotificationTargets(t *testing.T) {
 // when ctx1 (the first parent, e.g. the HTTP request context) is cancelled.
 func TestWithEitherCancel_Ctx1Cancel(t *testing.T) {
 	ctx1, cancel1 := context.WithCancel(context.Background())
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	defer cancel2()
+	ctx2 := t.Context()
 
 	merged, cancelMerged := withEitherCancel(ctx1, ctx2)
 	defer cancelMerged()
@@ -885,9 +884,8 @@ func TestWithEitherCancel_Ctx1Cancel(t *testing.T) {
 // TestWithEitherCancel_Ctx2Cancel verifies that the derived context is cancelled
 // when ctx2 (the second parent, e.g. the queue-task context) is cancelled.
 func TestWithEitherCancel_Ctx2Cancel(t *testing.T) {
-	ctx1, cancel1 := context.WithCancel(context.Background())
+	ctx1 := t.Context()
 	ctx2, cancel2 := context.WithCancel(context.Background())
-	defer cancel1()
 
 	merged, cancelMerged := withEitherCancel(ctx1, ctx2)
 	defer cancelMerged()
@@ -948,8 +946,7 @@ func TestWithEitherCancel_ExplicitCancel(t *testing.T) {
 // preventing goroutine leaks.
 func TestWithEitherCancel_NoGoroutineLeak(t *testing.T) {
 	ctx1, cancel1 := context.WithCancel(context.Background())
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	defer cancel2()
+	ctx2 := t.Context()
 
 	goroutinesBefore := runtime.NumGoroutine()
 
@@ -969,8 +966,9 @@ func TestWithEitherCancel_NoGoroutineLeak(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	goroutinesAfter := runtime.NumGoroutine()
 
+	// Allow a ±1 goroutine variance due to runtime scheduling
 	assert.LessOrEqual(t, goroutinesAfter, goroutinesBefore+1,
-		"goroutine count should return to baseline after cancellation (allow ±1 for runtime variance)")
+		"goroutine count should be near baseline after cancellation")
 
 	// merged context must be done
 	select {
@@ -987,8 +985,7 @@ func TestWithEitherCancel_AlreadyCancelledCtx1(t *testing.T) {
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	cancel1() // already cancelled
 
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	defer cancel2()
+	ctx2 := t.Context()
 
 	merged, cancelMerged := withEitherCancel(ctx1, ctx2)
 	defer cancelMerged()
@@ -1004,8 +1001,7 @@ func TestWithEitherCancel_AlreadyCancelledCtx1(t *testing.T) {
 // TestWithEitherCancel_AlreadyCancelledCtx2 verifies that if ctx2 is already
 // cancelled before withEitherCancel is called, the merged context is cancelled promptly.
 func TestWithEitherCancel_AlreadyCancelledCtx2(t *testing.T) {
-	ctx1, cancel1 := context.WithCancel(context.Background())
-	defer cancel1()
+	ctx1 := t.Context()
 
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	cancel2() // already cancelled


### PR DESCRIPTION
Previously, handleNotification accepted a context.Context parameter but ignored it (_ context.Context). The context passed from pushHandler (c.Request.Context()) was therefore never used when dispatching notifications, so client disconnection could not cancel in-flight push tasks.

This commit:
1. Renames the ignored parameter to `ctx` so it is actually used.
2. Adds a withEitherCancel helper that merges the HTTP request context with the queue-task context, cancelling when either is done (client disconnects OR queue shuts down).
3. Threads the merged context through to notify.SendNotification, which already propagates it to PushToIOS / PushToAndroid / PushToHuawei and DispatchFeedback.

This completes the fix originally intended by the goroutine pattern in issue #422, which was removed in #866 because the cancel() call was never reached in async mode.