### PR TITLE
fix(fcm): always propagate delivery priority to AndroidConfig

### DIFF
--- a/notify/notification_fcm.go
+++ b/notify/notification_fcm.go
@@ -141,6 +141,20 @@ func setupFCMSound(req *PushNotification) {
 	}
 }
 
+// setupFCMPriority propagates the delivery priority to the AndroidConfig so it
+// is honored even for data-only messages that have no sound or notification.
+func setupFCMPriority(req *PushNotification) {
+	if req.Priority == "" {
+		return
+	}
+	switch {
+	case req.Android == nil:
+		req.Android = &messaging.AndroidConfig{Priority: req.Priority}
+	case req.Android.Priority == "":
+		req.Android.Priority = req.Priority
+	}
+}
+
 // convertDataToStringMap converts the request data to a string map.
 func convertDataToStringMap(data map[string]any) map[string]string {
 	if len(data) == 0 {
@@ -182,6 +196,7 @@ func GetAndroidNotification(req *PushNotification) []*messaging.Message {
 	setupFCMNotification(req)
 	setupFCMContentAvailable(req)
 	setupFCMSound(req)
+	setupFCMPriority(req)
 
 	data := convertDataToStringMap(req.Data)
 	var messages []*messaging.Message

--- a/notify/notification_fcm_test.go
+++ b/notify/notification_fcm_test.go
@@ -474,3 +474,21 @@ func TestGetAndroidNotificationWithTopicAndTokens(t *testing.T) {
 	assert.Equal(t, "token1", messages[1].Token)
 	assert.Equal(t, "token2", messages[2].Token)
 }
+
+func TestFCMDataOnlyMessageKeepsHighPriority(t *testing.T) {
+	req := &PushNotification{
+		Tokens:   []string{"test-token"},
+		Platform: core.PlatFormAndroid,
+		Priority: "high",
+		Data: map[string]any{
+			"type":    "xcall",
+			"room_id": "t_47189",
+		},
+	}
+
+	messages := GetAndroidNotification(req)
+
+	assert.Len(t, messages, 1)
+	assert.NotNil(t, messages[0].Android)
+	assert.Equal(t, "high", messages[0].Android.Priority)
+}


### PR DESCRIPTION
Data-only messages without a sound never reached setupFCMSound, so req.Priority was dropped and FCM defaulted them to normal priority.

fix #875 