### PR TITLE
fix(apns): copy client per request to avoid shared host mutation

### DIFF
--- a/notify/notification_apns.go
+++ b/notify/notification_apns.go
@@ -452,20 +452,25 @@ func GetIOSNotification(req *PushNotification) *apns2.Notification {
 	return notification
 }
 
-func getApnsClient(cfg *config.ConfYaml, req *PushNotification) (client *apns2.Client) {
+func getApnsClient(cfg *config.ConfYaml, req *PushNotification) *apns2.Client {
+	// Copy the shared client so setting the host per request does not mutate the
+	// process-wide ApnsClient. apns2's Production/Development mutate the receiver,
+	// so calling them on the global would race and could redirect concurrent
+	// pushes to the wrong host. HTTPClient and Token are safe to share.
+	client := *ApnsClient
 	switch {
 	case req.Production:
-		client = ApnsClient.Production()
+		client.Host = apns2.HostProduction
 	case req.Development:
-		client = ApnsClient.Development()
+		client.Host = apns2.HostDevelopment
 	default:
 		if cfg.Ios.Production {
-			client = ApnsClient.Production()
+			client.Host = apns2.HostProduction
 		} else {
-			client = ApnsClient.Development()
+			client.Host = apns2.HostDevelopment
 		}
 	}
-	return client
+	return &client
 }
 
 // PushToIOS provide send notification to APNs server.

--- a/notify/notification_apns_host_test.go
+++ b/notify/notification_apns_host_test.go
@@ -1,0 +1,92 @@
+package notify
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/appleboy/gorush/config"
+
+	"github.com/sideshow/apns2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getApnsClient must pick the APNs host from the per-request override first,
+// then fall back to the iOS config default.
+func TestGetApnsClientHost(t *testing.T) {
+	cfg, err := config.LoadConf()
+	require.NoError(t, err)
+	cfg.Ios.Enabled = true
+	cfg.Ios.KeyPath = testKeyPath
+	require.NoError(t, InitAPNSClient(context.Background(), cfg))
+
+	tests := []struct {
+		name          string
+		cfgProduction bool
+		req           *PushNotification
+		wantHost      string
+	}{
+		{"request production override", false, &PushNotification{Production: true}, apns2.HostProduction},
+		{"request development override", true, &PushNotification{Development: true}, apns2.HostDevelopment},
+		{"config production default", true, &PushNotification{}, apns2.HostProduction},
+		{"config development default", false, &PushNotification{}, apns2.HostDevelopment},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg.Ios.Production = tt.cfgProduction
+			got := getApnsClient(cfg, tt.req)
+			assert.Equal(t, tt.wantHost, got.Host)
+		})
+	}
+}
+
+// Resolving a client for one request must not change the host of a client
+// already handed to another request. Before the fix, getApnsClient returned the
+// shared global and mutated its Host in place, so a later development request
+// silently repointed an earlier production client at the sandbox.
+func TestGetApnsClientNoSharedMutation(t *testing.T) {
+	cfg, err := config.LoadConf()
+	require.NoError(t, err)
+	cfg.Ios.Enabled = true
+	cfg.Ios.KeyPath = testKeyPath
+	require.NoError(t, InitAPNSClient(context.Background(), cfg))
+
+	prod := getApnsClient(cfg, &PushNotification{Production: true})
+	require.Equal(t, apns2.HostProduction, prod.Host)
+
+	// Unrelated later request for the other environment.
+	dev := getApnsClient(cfg, &PushNotification{Development: true})
+
+	assert.Equal(t, apns2.HostProduction, prod.Host,
+		"production client host was mutated by a later development request")
+	assert.Equal(t, apns2.HostDevelopment, dev.Host)
+	assert.NotSame(t, ApnsClient, prod, "must not hand back the shared global client")
+}
+
+// Concurrent resolution for different environments must not race on the shared
+// global. Run with -race to exercise the regression.
+func TestGetApnsClientConcurrent(t *testing.T) {
+	cfg, err := config.LoadConf()
+	require.NoError(t, err)
+	cfg.Ios.Enabled = true
+	cfg.Ios.KeyPath = testKeyPath
+	require.NoError(t, InitAPNSClient(context.Background(), cfg))
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			c := getApnsClient(cfg, &PushNotification{Production: true})
+			assert.Equal(t, apns2.HostProduction, c.Host)
+		}()
+		go func() {
+			defer wg.Done()
+			c := getApnsClient(cfg, &PushNotification{Development: true})
+			assert.Equal(t, apns2.HostDevelopment, c.Host)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #881.

Opening this proactively with a fix. If mutating the shared client is intentional and I have misread the send path, happy to close.

I went looking at why some iOS pushes can land in the wrong APNs environment. It comes down to [`getApnsClient`](https://github.com/appleboy/gorush/blob/891b4530db8f5db2beeb44b42665999ab802799f/notify/notification_apns.go#L455-L469): it picks the environment by calling `Production()` / `Development()` on the shared global `ApnsClient`, and in apns2 those two methods mutate the receiver and return it rather than handing back a configured copy. So every call rewrites `ApnsClient.Host` on the single process-wide client and returns that same pointer.

Once more than one push is in flight (and `worker_num` defaults to `runtime.NumCPU()`, so that is the normal case) two things go wrong:

1. It is a data race on `ApnsClient.Host`. It happens even when both requests want the same host, because both still write the field.
2. When two requests disagree, the last writer wins for everyone. `PushToIOS` resolves the client once and then fans out into goroutines that each read the host when they build their request, so a later request can redirect pushes that were already in flight. A `production: true` notification can go to the sandbox, and a `development: true` one to production.

It is easy to miss in practice because Apple just returns a generic `BadDeviceToken` for a wrong-environment token, so it looks like ordinary token churn and the rate tracks your traffic mix. The full write-up, a deterministic reproduction, and the `-race` output are in #881.

The fix is small: copy the client per request and set the host on the copy, so the global is never touched.

```go
client := *ApnsClient
switch {
case req.Production:
	client.Host = apns2.HostProduction
case req.Development:
	client.Host = apns2.HostDevelopment
default:
	if cfg.Ios.Production {
		client.Host = apns2.HostProduction
	} else {
		client.Host = apns2.HostDevelopment
	}
}
return &client
```

`apns2.Client` is a plain struct with no lock, and its `HTTPClient` and `Token` are safe to share, so the copy is cheap and keeps the same connection pool.

Tests live in `notify/notification_apns_host_test.go`:

* host selection for both the per-request override and the config default,
* a regression test that a later development request no longer repoints an earlier production client (it fails on `master` today),
* a concurrent test that stays clean under `-race`.

I kept this to `getApnsClient` alone. Running the whole package under `-race` also turns up a separate, older race on the `resp.Logs` / `newTokens` appends in `PushToIOS`, but that one is already being handled in #874, so I left it out here.
